### PR TITLE
improve OpenTelemetry attributes and enable tracing visibility

### DIFF
--- a/connector/types.go
+++ b/connector/types.go
@@ -90,7 +90,7 @@ type serveOptions struct {
 func defaultServeOptions() *serveOptions {
 	return &serveOptions{
 		logger:          log.Level(zerolog.GlobalLevel()),
-		serviceName:     "ndc-go",
+		serviceName:     "hasura-ndc-go",
 		version:         "0.1.0",
 		withoutConfig:   false,
 		withoutRecovery: false,


### PR DESCRIPTION
- OpenTelemetry spans are now attributed with `internal.visibility: "user"` so that they show up in the Hasura Console.
- Wrap the `Tracer` with  `internal.visibility: "user"` attribute by default. Use `StartInternal` if you want to hide internal spans.