### PR TITLE
Change init command to new

### DIFF
--- a/cmd/ndc-go-sdk/README.md
+++ b/cmd/ndc-go-sdk/README.md
@@ -30,10 +30,10 @@ Flags:
   -h, --help    Show context-sensitive help.
 
 Commands:
-  init --name=STRING --module=STRING
+  new --name=STRING --module=STRING
     Initialize an NDC connector boilerplate. For example:
 
-        ndc-go-sdk init -n example -m github.com/foo/example
+        ndc-go-sdk new -n example -m github.com/foo/example
 
   generate
     Generate schema and implementation for the connector from functions.
@@ -41,7 +41,7 @@ Commands:
 
 ### Initialize connector project
 
-The `init` command generates a boilerplate project for connector development from [template](templates/new) with the following folder structure:
+The `new` command generates a boilerplate project for connector development from [template](templates/new) with the following folder structure:
 
 - `functions`: the folder contains query and mutation functions. The `generate` command will parse `.go` files in this folder.
 - `types`: the folder contains reusable types such as `RawConfiguration`, `Configuration` and `State`.
@@ -54,7 +54,7 @@ The `init` command generates a boilerplate project for connector development fro
 The command requires names of the connector and module. By default, the tool creates a new folder with the connector name. If you want to customize the path or generate files in the current folder. use `--output` (`-o`) argument.
 
 ```bash
-ndc-go-sdk init -n example -m github.com/foo/example -o .
+ndc-go-sdk new -n example -m github.com/foo/example -o .
 ```
 
 ### Generate queries and mutations

--- a/cmd/ndc-go-sdk/main.go
+++ b/cmd/ndc-go-sdk/main.go
@@ -11,12 +11,12 @@ import (
 )
 
 var cli struct {
-	Init struct {
+	New struct {
 		Name     string `help:"Name of the connector." short:"n" required:""`
 		Module   string `help:"Module name of the connector" short:"m" required:""`
 		Output   string `help:"The location where source codes will be generated" short:"o" default:""`
 		LogLevel string `help:"Log level." enum:"trace,debug,info,warn,error" default:"info"`
-	} `cmd:"" help:"Initialize an NDC connector boilerplate. For example:\n ndc-go-sdk init -n example -m github.com/foo/example"`
+	} `cmd:"" help:"Initialize an NDC connector boilerplate. For example:\n ndc-go-sdk new -n example -m github.com/foo/example"`
 
 	Generate struct {
 		Path        string   `help:"The base path of the connector's source code" short:"p" default:"."`
@@ -30,14 +30,14 @@ var cli struct {
 func main() {
 	cmd := kong.Parse(&cli)
 	switch cmd.Command() {
-	case "init":
-		setupGlobalLogger(cli.Init.LogLevel)
+	case "new":
+		setupGlobalLogger(cli.New.LogLevel)
 		log.Info().
-			Str("name", cli.Init.Name).
-			Str("module", cli.Init.Module).
-			Str("output", cli.Init.Output).
+			Str("name", cli.New.Name).
+			Str("module", cli.New.Module).
+			Str("output", cli.New.Output).
 			Msg("generating the NDC boilerplate...")
-		if err := generateNewProject(cli.Init.Name, cli.Init.Module, cli.Init.Output, false); err != nil {
+		if err := generateNewProject(cli.New.Name, cli.New.Module, cli.New.Output, false); err != nil {
 			log.Fatal().Err(err).Msg("failed to generate new project")
 		}
 		log.Info().Msg("generated successfully")

--- a/cmd/ndc-go-sdk/templates/new/.gitgnore.tmpl
+++ b/cmd/ndc-go-sdk/templates/new/.gitgnore.tmpl
@@ -1,1 +1,25 @@
-dist/
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Text editor settings
+.idea/
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace files
+go.work
+go.work.sum


### PR DESCRIPTION
- Change the `init` command to `new`. We may use the `init` command for NDC CLI plugin specification later
- Update `.gitignore` template