### PR TITLE
codegen: drop time.Duration support and update UUID scalar codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 
 .PHONY: build-codegen
 build-codegen:
-	cd ./cmd/ndc-go-sdk && go build -o ../../_output/ndc-go-sdk .
+	cd ./cmd/ndc-go-sdk && go build -o ../../_output/hasura-ndc-go .
 	
 # build the build-codegen cli for all given platform/arch
 .PHONY: build-codegen
@@ -36,5 +36,5 @@ ci-build-codegen: clean
 	go get github.com/mitchellh/gox && \
 	go run github.com/mitchellh/gox -ldflags '-X github.com/hasura/ndc-sdk-go/cmd/ndc-go-sdk/version.BuildVersion=$(VERSION) -s -w -extldflags "-static"' \
 		-osarch="linux/amd64 darwin/amd64 windows/amd64 darwin/arm64" \
-		-output="../../$(OUTPUT_DIR)/$(VERSION)/ndc-go-sdk-{{.OS}}-{{.Arch}}" \
+		-output="../../$(OUTPUT_DIR)/$(VERSION)/hasura-ndc-go-{{.OS}}-{{.Arch}}" \
 		.

--- a/cmd/ndc-go-sdk/README.md
+++ b/cmd/ndc-go-sdk/README.md
@@ -10,21 +10,28 @@ The generator is inspired by [ndc-typescript-deno](https://github.com/hasura/ndc
 
 Get a release [here](https://github.com/hasura/ndc-sdk-go/releases).
 
-### Install from source
+```sh
+
+```
+
+### Build from source
 
 To install with Go 1.19+:
 
 ```bash
 git clone github.com/hasura/ndc-sdk-go
-cd cmd/ndc-go-sdk
-go install .
+cd ndc-sdk-go
+make build-codegen
+
+# (optional) move the binary to the /bin
+# sudo mv _output/hasura-ndc-go /bin/hasura-ndc-go
 ```
 
 ## How to Use
 
 ```bash
-❯ ndc-go-sdk -h
-Usage: ndc-go-sdk <command>
+❯ hasura-ndc-go -h
+Usage: hasura-ndc-go <command>
 
 Flags:
   -h, --help    Show context-sensitive help.
@@ -33,7 +40,7 @@ Commands:
   new --name=STRING --module=STRING
     Initialize an NDC connector boilerplate. For example:
 
-        ndc-go-sdk new -n example -m github.com/foo/example
+        hasura-ndc-go new -n example -m github.com/foo/example
 
   generate
     Generate schema and implementation for the connector from functions.
@@ -54,7 +61,7 @@ The `new` command generates a boilerplate project for connector development from
 The command requires names of the connector and module. By default, the tool creates a new folder with the connector name. If you want to customize the path or generate files in the current folder. use `--output` (`-o`) argument.
 
 ```bash
-ndc-go-sdk new -n example -m github.com/foo/example -o .
+hasura-ndc-go new -n example -m github.com/foo/example -o .
 ```
 
 ### Generate queries and mutations
@@ -65,7 +72,7 @@ The `generate` command parses code in the `functions` folder, finds functions an
 - `connector.generated.go`: implement `GetSchema`, `Query` and `Mutation` methods with exposed functions.
 
 ```bash
-ndc-go-sdk generate
+hasura-ndc-go generate
 ```
 
 ## How it works
@@ -179,7 +186,6 @@ The basic scalar types supported are:
 - `float32`, `float64` (NDC scalar type: `Float`)
 - `bool` (NDC scalar type: `Boolean`)
 - `time.Time` (NDC scalar type: `DateTime`, represented as an [ISO formatted](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) string in JSON)
-- `time.Duration` (NDC scalar type: `Duration`, represented as an int64 nanosecond duration in JSON)
 - `github.com/google/uuid.UUID` (NDC scalar type: `UUID`, represented as a UUID string in JSON)
 
 Alias scalar types will be inferred to the origin type in the schema.

--- a/cmd/ndc-go-sdk/README.md
+++ b/cmd/ndc-go-sdk/README.md
@@ -10,10 +10,6 @@ The generator is inspired by [ndc-typescript-deno](https://github.com/hasura/ndc
 
 Get a release [here](https://github.com/hasura/ndc-sdk-go/releases).
 
-```sh
-
-```
-
 ### Build from source
 
 To install with Go 1.19+:
@@ -23,8 +19,8 @@ git clone github.com/hasura/ndc-sdk-go
 cd ndc-sdk-go
 make build-codegen
 
-# (optional) move the binary to the /bin
-# sudo mv _output/hasura-ndc-go /bin/hasura-ndc-go
+# (optional) move the binary to /usr/bin
+# sudo mv _output/hasura-ndc-go /usr/bin/hasura-ndc-go
 ```
 
 ## How to Use

--- a/cmd/ndc-go-sdk/connector_test.go
+++ b/cmd/ndc-go-sdk/connector_test.go
@@ -21,10 +21,11 @@ import (
 var (
 	newLinesRegexp = regexp.MustCompile(`\n(\s|\t)*\n`)
 	tabRegexp      = regexp.MustCompile(`\t`)
+	spacesRegexp   = regexp.MustCompile(`\n\s+`)
 )
 
 func formatTextContent(input string) string {
-	return tabRegexp.ReplaceAllString(newLinesRegexp.ReplaceAllString(input, "\n"), "  ")
+	return spacesRegexp.ReplaceAllString(tabRegexp.ReplaceAllString(newLinesRegexp.ReplaceAllString(input, "\n"), "  "), "\n")
 }
 
 func TestConnectorGeneration(t *testing.T) {

--- a/cmd/ndc-go-sdk/constant.go
+++ b/cmd/ndc-go-sdk/constant.go
@@ -1,0 +1,104 @@
+package main
+
+const (
+	connectorOutputFile   = "connector.generated.go"
+	schemaOutputFile      = "schema.generated.json"
+	typeMethodsOutputFile = "types.generated.go"
+	googleUuidPackageName = "github.com/google/uuid"
+)
+
+const textBlockErrorCheck = `
+    if err != nil {
+		  return err
+    }
+`
+
+const textBlockErrorCheck2 = `
+    if err != nil {
+      return nil, err
+    }
+`
+const textBlockUUIDParsers = `
+func decodeUUIDHookFunc() mapstructure.DecodeHookFunc {
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		if to.PkgPath() != "github.com/google/uuid" || to.Name() != "UUID" {
+			return data, nil
+		}
+		result, err := _parseNullableUUID(data)
+		if err != nil || result == nil {
+			return uuid.UUID{}, err
+		}
+
+		return *result, nil
+	}
+}
+
+func _parseUUID(value any) (uuid.UUID, error) {
+	result, err := _parseNullableUUID(value)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	if result == nil {
+		return uuid.UUID{}, errors.New("the uuid value must not be null")
+	}
+	return *result, nil
+}
+
+func _parseNullableUUID(value any) (*uuid.UUID, error) {
+	if utils.IsNil(value) {
+		return nil, nil
+	}
+	switch v := value.(type) {
+	case string:
+		result, err := uuid.Parse(v)
+		if err != nil {
+			return nil, err
+		}
+		return &result, nil
+	case *string:
+		if v == nil {
+			return nil, nil
+		}
+		result, err := uuid.Parse(*v)
+		if err != nil {
+			return nil, err
+		}
+		return &result, nil
+	case [16]byte:
+		result := uuid.UUID(v)
+		return &result, nil
+	case *[16]byte:
+		if v == nil {
+			return nil, nil
+		}
+		result := uuid.UUID(*v)
+		return &result, nil
+	default:
+		return nil, fmt.Errorf("failed to parse uuid, got: %+v", value)
+	}
+}
+
+func _getObjectUUID(object map[string]any, key string) (uuid.UUID, error) {
+	value, ok := utils.GetAny(object, key)
+	if !ok {
+		return uuid.UUID{}, fmt.Errorf("field %s is required", key)
+	}
+	result, err := _parseUUID(value)
+	if err != nil {
+		return result, fmt.Errorf("%s: %s", key, err)
+	}
+	return result, nil
+}
+
+func _getNullableObjectUUID(object map[string]any, key string) (*uuid.UUID, error) {
+	value, ok := utils.GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := _parseNullableUUID(value)
+	if err != nil {
+		return result, fmt.Errorf("%s: %s", key, err)
+	}
+	return result, nil
+}
+`

--- a/cmd/ndc-go-sdk/schema.go
+++ b/cmd/ndc-go-sdk/schema.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/importer"
@@ -24,7 +25,6 @@ var defaultScalarTypes = schema.SchemaResponseScalarTypes{
 	"Float":    *schema.NewScalarType(),
 	"Boolean":  *schema.NewScalarType(),
 	"DateTime": *schema.NewScalarType(),
-	"Duration": *schema.NewScalarType(),
 }
 
 var ndcOperationNameRegex = regexp.MustCompile(`^(Function|Procedure)([A-Z][A-Za-z0-9]*)$`)
@@ -449,7 +449,7 @@ func (sp *SchemaParser) parseType(rawSchema *RawConnectorSchema, rootType *TypeI
 				case "Time":
 					scalarName = "DateTime"
 				case "Duration":
-					scalarName = "Duration"
+					return nil, errors.New("unsupported type time.Duration. Create a scalar type wrapper with FromValue method to decode the any value")
 				}
 			case "github.com/google/uuid":
 				switch innerType.Name() {

--- a/cmd/ndc-go-sdk/testdata/basic/expected/functions.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/functions.go.tmpl
@@ -2,18 +2,19 @@
 package functions
 
 import (
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/hasura/ndc-sdk-go/utils"
 )
-
+var functions_Decoder = utils.NewDecoder()
 // FromValue decodes values from map
 func (j *GetTypesArguments) FromValue(input map[string]any) error {
 	var err error
-	err = utils.DecodeObjectValue(&j.ArrayObject, input, "ArrayObject")
+	err = functions_Decoder.DecodeObjectValue(&j.ArrayObject, input, "ArrayObject")
 	if err != nil {
 		return err
 	}
 	j.ArrayObjectPtr = new([]struct{Content string "json:\"content\""})
-	err = utils.DecodeNullableObjectValue(j.ArrayObjectPtr, input, "ArrayObjectPtr")
+	err = functions_Decoder.DecodeNullableObjectValue(j.ArrayObjectPtr, input, "ArrayObjectPtr")
 	if err != nil {
 		return err
 	}
@@ -25,20 +26,12 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 	if err != nil {
 		return err
 	}
-	err = utils.DecodeObjectValue(&j.CustomScalar, input, "CustomScalar")
+	err = functions_Decoder.DecodeObjectValue(&j.CustomScalar, input, "CustomScalar")
 	if err != nil {
 		return err
 	}
 	j.CustomScalarPtr = new(CommentText)
-	err = utils.DecodeNullableObjectValue(j.CustomScalarPtr, input, "CustomScalarPtr")
-	if err != nil {
-		return err
-	}
-	j.Duration, err = utils.GetDuration(input, "Duration")
-	if err != nil {
-		return err
-	}
-	j.DurationPtr, err = utils.GetNullableDuration(input, "DurationPtr")
+	err = functions_Decoder.DecodeNullableObjectValue(j.CustomScalarPtr, input, "CustomScalarPtr")
 	if err != nil {
 		return err
 	}
@@ -98,30 +91,30 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 	if err != nil {
 		return err
 	}
-	err = utils.DecodeObjectValue(&j.NamedArray, input, "NamedArray")
+	err = functions_Decoder.DecodeObjectValue(&j.NamedArray, input, "NamedArray")
 	if err != nil {
 		return err
 	}
 	j.NamedArrayPtr = new([]Author)
-	err = utils.DecodeNullableObjectValue(j.NamedArrayPtr, input, "NamedArrayPtr")
+	err = functions_Decoder.DecodeNullableObjectValue(j.NamedArrayPtr, input, "NamedArrayPtr")
 	if err != nil {
 		return err
 	}
-	err = utils.DecodeObjectValue(&j.NamedObject, input, "NamedObject")
+	err = functions_Decoder.DecodeObjectValue(&j.NamedObject, input, "NamedObject")
 	if err != nil {
 		return err
 	}
 	j.NamedObjectPtr = new(Author)
-	err = utils.DecodeNullableObjectValue(j.NamedObjectPtr, input, "NamedObjectPtr")
+	err = functions_Decoder.DecodeNullableObjectValue(j.NamedObjectPtr, input, "NamedObjectPtr")
 	if err != nil {
 		return err
 	}
-	err = utils.DecodeObjectValue(&j.Object, input, "Object")
+	err = functions_Decoder.DecodeObjectValue(&j.Object, input, "Object")
 	if err != nil {
 		return err
 	}
 	j.ObjectPtr = new(struct{Long int; Lat int})
-	err = utils.DecodeNullableObjectValue(j.ObjectPtr, input, "ObjectPtr")
+	err = functions_Decoder.DecodeNullableObjectValue(j.ObjectPtr, input, "ObjectPtr")
 	if err != nil {
 		return err
 	}
@@ -198,7 +191,6 @@ func (j *GetArticlesArguments) FromValue(input map[string]any) error {
 func (j Author) ToMap() map[string]any {
 	result := map[string]any{
 		"created_at": j.CreatedAt,
-		"duration": j.Duration,
 		"id": j.ID,
 	}
 	return result
@@ -248,20 +240,20 @@ func (j GetTypesArguments) ToMap() map[string]any {
 	var result_ArrayObjectPtr []map[string]any
 	if j.ArrayObjectPtr != nil {
 	result_ArrayObjectPtr = make([]map[string]any, len(*j.ArrayObjectPtr))
-	for i, _item := range *j.ArrayObjectPtr {
-	item := map[string]any{
-		"content": _item.Content,
+	for i, result_ArrayObjectPtr_value := range *j.ArrayObjectPtr {
+	result_ArrayObjectPtr_item := map[string]any{
+		"content": result_ArrayObjectPtr_value.Content,
 	}
-		result_ArrayObjectPtr[i] = item
+		result_ArrayObjectPtr[i] = result_ArrayObjectPtr_item
 	}
 }
 	var result_ArrayObject []map[string]any
 	result_ArrayObject = make([]map[string]any, len(j.ArrayObject))
-	for i, _item := range j.ArrayObject {
-	item := map[string]any{
-		"content": _item.Content,
+	for i, result_ArrayObject_value := range j.ArrayObject {
+	result_ArrayObject_item := map[string]any{
+		"content": result_ArrayObject_value.Content,
 	}
-		result_ArrayObject[i] = item
+		result_ArrayObject[i] = result_ArrayObject_item
 	}
 	result := map[string]any{
 		"ArrayObject": result_ArrayObject,
@@ -270,8 +262,6 @@ func (j GetTypesArguments) ToMap() map[string]any {
 		"BoolPtr": j.BoolPtr,
 		"CustomScalar": j.CustomScalar,
 		"CustomScalarPtr": j.CustomScalarPtr,
-		"Duration": j.Duration,
-		"DurationPtr": j.DurationPtr,
 		"Float32": j.Float32,
 		"Float32Ptr": j.Float32Ptr,
 		"Float64": j.Float64,

--- a/cmd/ndc-go-sdk/testdata/basic/expected/schema.json
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/schema.json
@@ -63,21 +63,6 @@
             }
           }
         },
-        "Duration": {
-          "type": {
-            "name": "Duration",
-            "type": "named"
-          }
-        },
-        "DurationPtr": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Duration",
-              "type": "named"
-            }
-          }
-        },
         "Float32": {
           "type": {
             "name": "Float",
@@ -389,12 +374,6 @@
             "type": "named"
           }
         },
-        "duration": {
-          "type": {
-            "name": "Duration",
-            "type": "named"
-          }
-        },
         "id": {
           "type": {
             "name": "String",
@@ -526,21 +505,6 @@
             "type": "nullable",
             "underlying_type": {
               "name": "CommentString",
-              "type": "named"
-            }
-          }
-        },
-        "Duration": {
-          "type": {
-            "name": "Duration",
-            "type": "named"
-          }
-        },
-        "DurationPtr": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Duration",
               "type": "named"
             }
           }
@@ -969,10 +933,6 @@
       "comparison_operators": {}
     },
     "DateTime": {
-      "aggregate_functions": {},
-      "comparison_operators": {}
-    },
-    "Duration": {
       "aggregate_functions": {},
       "comparison_operators": {}
     },

--- a/cmd/ndc-go-sdk/testdata/basic/source/comment.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/source/comment.go.tmpl
@@ -38,7 +38,6 @@ type CreateArticleArguments struct {
 
 type Author struct {
   ID          string    `json:"id"`
-  Duration    time.Duration `json:"duration"`
   CreatedAt   time.Time `json:"created_at"`
 }
 

--- a/cmd/ndc-go-sdk/testdata/basic/source/prefix.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/source/prefix.go.tmpl
@@ -94,7 +94,6 @@ type GetTypesArguments struct {
 	Float32      float32
 	Float64      float64
 	Time         time.Time
-	Duration     time.Duration
 	CustomScalar CommentText
 
 	BoolPtr         *bool
@@ -112,7 +111,6 @@ type GetTypesArguments struct {
 	Float32Ptr      *float32
 	Float64Ptr      *float64
 	TimePtr         *time.Time
-	DurationPtr     *time.Duration
 	CustomScalarPtr *CommentText
 
 	Object struct {

--- a/example/codegen/connector_test.go
+++ b/example/codegen/connector_test.go
@@ -116,6 +116,10 @@ func TestQueryGetTypes(t *testing.T) {
 							"type": "literal",
 							"value": "10s"
 						},
+						"Text": {
+							"type": "literal",
+							"value": "text"
+						},
 						"CustomScalar": {
 							"type": "literal",
 							"value": "a comment"
@@ -189,6 +193,10 @@ func TestQueryGetTypes(t *testing.T) {
 							"type": "literal",
 							"value": "1m"
 						},
+						"TextPtr": {
+							"type": "literal",
+							"value": "text pointer"
+						},
 						"CustomScalarPtr": {
 							"type": "literal",
 							"value": "a comment pointer"
@@ -240,6 +248,10 @@ func TestQueryGetTypes(t *testing.T) {
 								"duration":  12,
 								"created_at": "2024-03-05T03:00:00Z"
 							}]
+						},
+						"UUIDArray": {
+							"type": "literal",
+							"value": ["b085b0b9-007c-440e-9661-0d8f2de98a5a", "b085b0b9-007c-440e-9661-0d8f2de98a5b"]
 						}
 				},
 				"query": {
@@ -311,6 +323,10 @@ func TestQueryGetTypes(t *testing.T) {
 								"Duration": {
 										"type": "column",
 										"column": "Duration"
+								},
+								"Text": {
+									"type": "column",
+									"column": "Text"
 								},
 								"CustomScalar": {
 									"type": "column",
@@ -384,6 +400,10 @@ func TestQueryGetTypes(t *testing.T) {
 										"type": "column",
 										"column": "DurationPtr"
 								},
+								"TextPtr": {
+									"type": "column",
+									"column": "TextPtr"
+								},
 								"CustomScalarPtr": {
 									"type": "column",
 									"column": "CustomScalarPtr"
@@ -415,6 +435,10 @@ func TestQueryGetTypes(t *testing.T) {
 								"NamedArray": {
 									"type": "column",
 									"column": "NamedArray"
+								},
+								"UUIDArray": {
+									"type": "column",
+									"column": "UUIDArray"
 								}
 						}
 				},
@@ -437,7 +461,7 @@ func TestQueryGetTypes(t *testing.T) {
 				Float32:         1.1,
 				Float64:         2.2,
 				Time:            time.Date(2024, 3, 5, 7, 0, 56, 0, time.UTC),
-				Duration:        10 * time.Second,
+				Text:            "text",
 				CustomScalar:    commentText,
 				UUIDPtr:         utils.ToPtr(uuid.MustParse("b085b0b9-007c-440e-9661-0d8f2de98a5b")),
 				BoolPtr:         utils.ToPtr(true),
@@ -455,7 +479,7 @@ func TestQueryGetTypes(t *testing.T) {
 				Float32Ptr:      utils.ToPtr(float32(3.3)),
 				Float64Ptr:      utils.ToPtr(float64(4.4)),
 				TimePtr:         utils.ToPtr(time.Date(2024, 3, 5, 7, 0, 0, 0, time.UTC)),
-				DurationPtr:     utils.ToPtr(time.Minute),
+				TextPtr:         utils.ToPtr(functions.Text("text pointer")),
 				CustomScalarPtr: &commentTextPtr,
 				Object: struct {
 					ID        uuid.UUID `json:"id"`
@@ -487,20 +511,21 @@ func TestQueryGetTypes(t *testing.T) {
 				},
 				NamedObject: functions.Author{
 					ID:        "1",
-					Duration:  10,
 					CreatedAt: time.Date(2024, 3, 5, 5, 0, 0, 0, time.UTC),
 				},
 				NamedObjectPtr: &functions.Author{
 					ID:        "2",
-					Duration:  11,
 					CreatedAt: time.Date(2024, 3, 5, 4, 0, 0, 0, time.UTC),
 				},
 				NamedArray: []functions.Author{
 					{
 						ID:        "3",
-						Duration:  12,
 						CreatedAt: time.Date(2024, 3, 5, 3, 0, 0, 0, time.UTC),
 					},
+				},
+				UUIDArray: []uuid.UUID{
+					uuid.MustParse("b085b0b9-007c-440e-9661-0d8f2de98a5a"),
+					uuid.MustParse("b085b0b9-007c-440e-9661-0d8f2de98a5b"),
 				},
 			},
 		},

--- a/example/codegen/functions/comment.go
+++ b/example/codegen/functions/comment.go
@@ -62,9 +62,8 @@ type CreateArticleArguments struct {
 }
 
 type Author struct {
-	ID        string        `json:"id"`
-	Duration  time.Duration `json:"duration"`
-	CreatedAt time.Time     `json:"created_at"`
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type CreateArticleResult struct {

--- a/example/codegen/functions/prefix.go
+++ b/example/codegen/functions/prefix.go
@@ -97,7 +97,7 @@ type GetTypesArguments struct {
 	Float32      float32
 	Float64      float64
 	Time         time.Time
-	Duration     time.Duration
+	Text         Text
 	CustomScalar CommentText
 
 	UUIDPtr         *uuid.UUID
@@ -116,7 +116,7 @@ type GetTypesArguments struct {
 	Float32Ptr      *float32
 	Float64Ptr      *float64
 	TimePtr         *time.Time
-	DurationPtr     *time.Duration
+	TextPtr         *Text
 	CustomScalarPtr *CommentText
 
 	Object struct {
@@ -137,6 +137,7 @@ type GetTypesArguments struct {
 	NamedObjectPtr *Author
 	NamedArray     []Author
 	NamedArrayPtr  *[]Author
+	UUIDArray      []uuid.UUID
 }
 
 func FunctionGetTypes(ctx context.Context, state *types.State, arguments *GetTypesArguments) (*GetTypesArguments, error) {

--- a/example/codegen/schema.generated.json
+++ b/example/codegen/schema.generated.json
@@ -63,21 +63,6 @@
             }
           }
         },
-        "Duration": {
-          "type": {
-            "name": "Duration",
-            "type": "named"
-          }
-        },
-        "DurationPtr": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Duration",
-              "type": "named"
-            }
-          }
-        },
         "Float32": {
           "type": {
             "name": "Float",
@@ -249,6 +234,21 @@
             }
           }
         },
+        "Text": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "TextPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
         "Time": {
           "type": {
             "name": "DateTime",
@@ -268,6 +268,15 @@
           "type": {
             "name": "UUID",
             "type": "named"
+          }
+        },
+        "UUIDArray": {
+          "type": {
+            "element_type": {
+              "name": "UUID",
+              "type": "named"
+            },
+            "type": "array"
           }
         },
         "UUIDPtr": {
@@ -401,12 +410,6 @@
         "created_at": {
           "type": {
             "name": "DateTime",
-            "type": "named"
-          }
-        },
-        "duration": {
-          "type": {
-            "name": "Duration",
             "type": "named"
           }
         },
@@ -545,21 +548,6 @@
             }
           }
         },
-        "Duration": {
-          "type": {
-            "name": "Duration",
-            "type": "named"
-          }
-        },
-        "DurationPtr": {
-          "type": {
-            "type": "nullable",
-            "underlying_type": {
-              "name": "Duration",
-              "type": "named"
-            }
-          }
-        },
         "Float32": {
           "type": {
             "name": "Float",
@@ -731,6 +719,21 @@
             }
           }
         },
+        "Text": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "TextPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
         "Time": {
           "type": {
             "name": "DateTime",
@@ -750,6 +753,15 @@
           "type": {
             "name": "UUID",
             "type": "named"
+          }
+        },
+        "UUIDArray": {
+          "type": {
+            "element_type": {
+              "name": "UUID",
+              "type": "named"
+            },
+            "type": "array"
           }
         },
         "UUIDPtr": {
@@ -999,10 +1011,6 @@
       "comparison_operators": {}
     },
     "DateTime": {
-      "aggregate_functions": {},
-      "comparison_operators": {}
-    },
-    "Duration": {
       "aggregate_functions": {},
       "comparison_operators": {}
     },


### PR DESCRIPTION
- Rename the binary name to `hasura-ndc-go` to follow the [NDC CLI plugin](https://github.com/hasura/ndc-hub/pull/92/files) specification. The codegen tool may be developed as a plugin in the future. 
- The `time.Duration` type doesn't support JSON decoding from string, e.g. `1s`, `1m`. So the codegen tool shouldn't support that type. Users need to define a scalar wrapper to support it themselves.
- Create a new `Decoder` type that wraps `mapstructure.Encoder` to support nested values mapping. Improve mapping from `any` types without falling back to JSON encoding/decoding. 
- `uuid.UUID` decoder is optionally generated if any argument or return type property contains this type. 
