### PR TITLE
fix: function query selection evaluation and improve OTEL propagator extraction

### DIFF
--- a/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
@@ -39,21 +39,20 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
     requestVars = []schema.QueryRequestVariablesElem{make(schema.QueryRequestVariablesElem)}
   }
 
-  var rowSets []schema.RowSet
-
-  for _, requestVar := range requestVars {
+  rowSets := make([]schema.RowSet, len(requestVars))
+  for i, requestVar := range requestVars {
     result, err := execQuery(ctx, state, request, valueField, requestVar)
     if err != nil {
       return nil, err
     }
-    rowSets = append(rowSets, schema.RowSet{
+    rowSets[i] = schema.RowSet{
       Aggregates: schema.RowSetAggregates{},
       Rows: []map[string]any{
         {
           "__value": result,
         },
       },
-    })
+    }
   }
 
   return rowSets, nil
@@ -61,16 +60,16 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
 
 // Mutation executes a mutation.
 func (c *Connector) Mutation(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.MutationRequest) (*schema.MutationResponse, error) {
-  operationResults := make([]schema.MutationOperationResults, 0, len(request.Operations))
+  operationResults := make([]schema.MutationOperationResults, len(request.Operations))
 
-  for _, operation := range request.Operations {
+  for i, operation := range request.Operations {
     switch operation.Type {
     case schema.MutationOperationProcedure:
       result, err := execProcedure(ctx, state, &operation)
       if err != nil {
         return nil, err
       }
-      operationResults = append(operationResults, result)
+      operationResults[i] = result
     default:
       return nil, schema.BadRequestError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
     }

--- a/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
@@ -30,6 +30,10 @@ func (c *Connector) GetSchema(configuration *types.Configuration) (*schema.Schem
 
 // Query executes a query.
 func (c *Connector) Query(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.QueryRequest) (schema.QueryResponse, error) {
+  valueField, err := utils.EvalFunctionSelectionFieldValue(request)
+  if err != nil {
+ 		return nil, schema.BadRequestError(err.Error(), nil)
+  }
   requestVars := request.Variables
   if len(requestVars) == 0 {
     requestVars = []schema.QueryRequestVariablesElem{make(schema.QueryRequestVariablesElem)}
@@ -38,7 +42,7 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
   var rowSets []schema.RowSet
 
   for _, requestVar := range requestVars {
-    result, err := execQuery(ctx, state, request, requestVar)
+    result, err := execQuery(ctx, state, request, valueField, requestVar)
     if err != nil {
       return nil, err
     }
@@ -77,7 +81,7 @@ func (c *Connector) Mutation(ctx context.Context, configuration *types.Configura
   }, nil
 }
 
-func execQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, variables map[string]any) (any, error) {
+func execQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, queryFields schema.NestedField, variables map[string]any) (any, error) {
 
   switch request.Collection {
 {{.Queries}}

--- a/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
@@ -33,38 +33,38 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
     requestVars = []schema.QueryRequestVariablesElem{make(schema.QueryRequestVariablesElem)}
   }
 
-  var rowSets []schema.RowSet
-  for _, requestVar := range requestVars {
-    result, err := execQuery(ctx, state, request, valueField, requestVar)
-    if err != nil {
-      return nil, err
-    }
-    rowSets = append(rowSets, schema.RowSet{
-      Aggregates: schema.RowSetAggregates{},
-      Rows: []map[string]any{
-        {
-          "__value": result,
-        },
-      },
-    })
-  }
+	rowSets := make([]schema.RowSet, len(requestVars))
+	for i, requestVar := range requestVars {
+		result, err := execQuery(ctx, state, request, valueField, requestVar)
+		if err != nil {
+			return nil, err
+		}
+		rowSets[i] = schema.RowSet{
+			Aggregates: schema.RowSetAggregates{},
+			Rows: []map[string]any{
+				{
+					"__value": result,
+				},
+			},
+		}
+	}
   return rowSets, nil
 }
 // Mutation executes a mutation.
 func (c *Connector) Mutation(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.MutationRequest) (*schema.MutationResponse, error) {
-  operationResults := make([]schema.MutationOperationResults, 0, len(request.Operations))
-  for _, operation := range request.Operations {
-    switch operation.Type {
-    case schema.MutationOperationProcedure:
-      result, err := execProcedure(ctx, state, &operation)
-      if err != nil {
-        return nil, err
-      }
-      operationResults = append(operationResults, result)
-    default:
-      return nil, schema.BadRequestError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
-    }
-  }
+  operationResults := make([]schema.MutationOperationResults, len(request.Operations))
+  for i, operation := range request.Operations {
+		switch operation.Type {
+		case schema.MutationOperationProcedure:
+			result, err := execProcedure(ctx, state, &operation)
+			if err != nil {
+				return nil, err
+			}
+			operationResults[i] = result
+		default:
+			return nil, schema.BadRequestError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
+		}
+	}
   return &schema.MutationResponse{
     OperationResults: operationResults,
   }, nil

--- a/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
@@ -24,13 +24,18 @@ func (c *Connector) GetSchema(configuration *types.Configuration) (*schema.Schem
 }
 // Query executes a query.
 func (c *Connector) Query(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.QueryRequest) (schema.QueryResponse, error) {
+  valueField, err := utils.EvalFunctionSelectionFieldValue(request)
+	if err != nil {
+		return nil, schema.BadRequestError(err.Error(), nil)
+	}
   requestVars := request.Variables
   if len(requestVars) == 0 {
     requestVars = []schema.QueryRequestVariablesElem{make(schema.QueryRequestVariablesElem)}
   }
+
   var rowSets []schema.RowSet
   for _, requestVar := range requestVars {
-    result, err := execQuery(ctx, state, request, requestVar)
+    result, err := execQuery(ctx, state, request, valueField, requestVar)
     if err != nil {
       return nil, err
     }
@@ -64,14 +69,21 @@ func (c *Connector) Mutation(ctx context.Context, configuration *types.Configura
     OperationResults: operationResults,
   }, nil
 }
-func execQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, variables map[string]any) (any, error) {
-  switch request.Collection {
-  case "getBool":
-    if len(request.Query.Fields) > 0 {
-      return nil, schema.BadRequestError("cannot evaluate selection fields for scalar", nil)
-    }
-    return functions.FunctionGetBool(ctx, state)
+func execQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, queryFields schema.NestedField, variables map[string]any) (any, error) {
+
+	switch request.Collection {
+	case "getBool":
+		if len(queryFields) > 0 {
+			return nil, schema.BadRequestError("cannot evaluate selection fields for scalar", nil)
+		}
+		return functions.FunctionGetBool(ctx, state)
 	case "getTypes":
+		selection, err := queryFields.AsObject()
+		if err != nil {
+			return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+				"cause": err.Error(),
+			})
+		}
 		rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
 		if err != nil {
 			return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
@@ -94,52 +106,70 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 			return nil, nil
 		}
 
-		result, err := utils.EncodeObjectWithColumnSelection(request.Query.Fields, rawResult)
+		result, err := utils.EvalNestedColumnObject(selection, rawResult)
 		if err != nil {
 			return nil, err
 		}
 		return result, nil
-  case "hello":
-    rawResult, err := functions.FunctionHello(ctx, state)
-    if err != nil {
-      return nil, err
-    }
-    if rawResult == nil {
-      return nil, nil
-    }
-    result, err := utils.EncodeObjectWithColumnSelection(request.Query.Fields, rawResult)
-    if err != nil {
-      return nil, err
-    }
-    return result, nil
-  case "getArticles":
-    rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
-    if err != nil {
-      return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
-        "cause": err.Error(),
-      })
-    }
-    var args functions.GetArticlesArguments
-    if err = args.FromValue(rawArgs); err != nil {
-      return nil, schema.BadRequestError("failed to resolve arguments", map[string]any{
-        "cause": err.Error(),
-      })
-    }
-    rawResult, err := functions.GetArticles(ctx, state, &args)
-    if err != nil {
-      return nil, err
-    }
+	case "hello":
+		selection, err := queryFields.AsObject()
+		if err != nil {
+			return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+				"cause": err.Error(),
+			})
+		}
+		rawResult, err := functions.FunctionHello(ctx, state)
+		if err != nil {
+			return nil, err
+		}
+
+		if rawResult == nil {
+			return nil, nil
+		}
+
+		result, err := utils.EvalNestedColumnObject(selection, rawResult)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	case "getArticles":
+		selection, err := queryFields.AsArray()
+		if err != nil {
+			return nil, schema.BadRequestError("the selection field type must be array", map[string]any{
+				"cause": err.Error(),
+			})
+		}
+		rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
+		if err != nil {
+			return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
+				"cause": err.Error(),
+			})
+		}
+
+		var args functions.GetArticlesArguments
+		if err = args.FromValue(rawArgs); err != nil {
+			return nil, schema.BadRequestError("failed to resolve arguments", map[string]any{
+				"cause": err.Error(),
+			})
+		}
+		rawResult, err := functions.GetArticles(ctx, state, &args)
+		if err != nil {
+			return nil, err
+		}
+
 		if rawResult == nil {
 			return nil, schema.BadRequestError("expected not null result", nil)
 		}
-    result, err := utils.EncodeObjectsWithColumnSelection(request.Query.Fields, rawResult)
-    if err != nil {
-      return nil, err
-    }
-    return result, nil
-  default:
-    return nil, schema.BadRequestError(fmt.Sprintf("unsupported query: %s", request.Collection), nil)
-  }
+
+		result, err := utils.EvalNestedColumnArrayIntoSlice(selection, rawResult)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+
+	default:
+		return nil, schema.BadRequestError(fmt.Sprintf("unsupported query: %s", request.Collection), nil)
+	}
 }
 func execProcedure(ctx context.Context, state *types.State, operation *schema.MutationOperation) (schema.MutationOperationResults, error) {
   var result any

--- a/connector/telemetry.go
+++ b/connector/telemetry.go
@@ -316,3 +316,7 @@ func (t *Tracer) StartInternal(ctx context.Context, spanName string, opts ...tra
 func httpStatusAttribute(code int) attribute.KeyValue {
 	return attribute.Int("http_status", code)
 }
+
+func isDebug() bool {
+	return zerolog.GlobalLevel() <= zerolog.DebugLevel
+}

--- a/connector/telemetry.go
+++ b/connector/telemetry.go
@@ -316,7 +316,3 @@ func (t *Tracer) StartInternal(ctx context.Context, spanName string, opts ...tra
 func httpStatusAttribute(code int) attribute.KeyValue {
 	return attribute.Int("http_status", code)
 }
-
-func isDebug() bool {
-	return zerolog.GlobalLevel() <= zerolog.DebugLevel
-}

--- a/example/codegen/connector.generated.go
+++ b/example/codegen/connector.generated.go
@@ -39,21 +39,20 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
 		requestVars = []schema.QueryRequestVariablesElem{make(schema.QueryRequestVariablesElem)}
 	}
 
-	var rowSets []schema.RowSet
-
-	for _, requestVar := range requestVars {
+	rowSets := make([]schema.RowSet, len(requestVars))
+	for i, requestVar := range requestVars {
 		result, err := execQuery(ctx, state, request, valueField, requestVar)
 		if err != nil {
 			return nil, err
 		}
-		rowSets = append(rowSets, schema.RowSet{
+		rowSets[i] = schema.RowSet{
 			Aggregates: schema.RowSetAggregates{},
 			Rows: []map[string]any{
 				{
 					"__value": result,
 				},
 			},
-		})
+		}
 	}
 
 	return rowSets, nil
@@ -61,16 +60,16 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
 
 // Mutation executes a mutation.
 func (c *Connector) Mutation(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.MutationRequest) (*schema.MutationResponse, error) {
-	operationResults := make([]schema.MutationOperationResults, 0, len(request.Operations))
+	operationResults := make([]schema.MutationOperationResults, len(request.Operations))
 
-	for _, operation := range request.Operations {
+	for i, operation := range request.Operations {
 		switch operation.Type {
 		case schema.MutationOperationProcedure:
 			result, err := execProcedure(ctx, state, &operation)
 			if err != nil {
 				return nil, err
 			}
-			operationResults = append(operationResults, result)
+			operationResults[i] = result
 		default:
 			return nil, schema.BadRequestError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
 		}

--- a/example/codegen/connector.generated.go
+++ b/example/codegen/connector.generated.go
@@ -30,6 +30,10 @@ func (c *Connector) GetSchema(configuration *types.Configuration) (*schema.Schem
 
 // Query executes a query.
 func (c *Connector) Query(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.QueryRequest) (schema.QueryResponse, error) {
+	valueField, err := utils.EvalFunctionSelectionFieldValue(request)
+	if err != nil {
+		return nil, schema.BadRequestError(err.Error(), nil)
+	}
 	requestVars := request.Variables
 	if len(requestVars) == 0 {
 		requestVars = []schema.QueryRequestVariablesElem{make(schema.QueryRequestVariablesElem)}
@@ -38,7 +42,7 @@ func (c *Connector) Query(ctx context.Context, configuration *types.Configuratio
 	var rowSets []schema.RowSet
 
 	for _, requestVar := range requestVars {
-		result, err := execQuery(ctx, state, request, requestVar)
+		result, err := execQuery(ctx, state, request, valueField, requestVar)
 		if err != nil {
 			return nil, err
 		}
@@ -77,15 +81,21 @@ func (c *Connector) Mutation(ctx context.Context, configuration *types.Configura
 	}, nil
 }
 
-func execQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, variables map[string]any) (any, error) {
+func execQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, queryFields schema.NestedField, variables map[string]any) (any, error) {
 
 	switch request.Collection {
 	case "getBool":
-		if len(request.Query.Fields) > 0 {
+		if len(queryFields) > 0 {
 			return nil, schema.BadRequestError("cannot evaluate selection fields for scalar", nil)
 		}
 		return functions.FunctionGetBool(ctx, state)
 	case "getTypes":
+		selection, err := queryFields.AsObject()
+		if err != nil {
+			return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+				"cause": err.Error(),
+			})
+		}
 		rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
 		if err != nil {
 			return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
@@ -108,12 +118,18 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 			return nil, nil
 		}
 
-		result, err := utils.EncodeObjectWithColumnSelection(request.Query.Fields, rawResult)
+		result, err := utils.EvalNestedColumnObject(selection, rawResult)
 		if err != nil {
 			return nil, err
 		}
 		return result, nil
 	case "hello":
+		selection, err := queryFields.AsObject()
+		if err != nil {
+			return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+				"cause": err.Error(),
+			})
+		}
 		rawResult, err := functions.FunctionHello(ctx, state)
 		if err != nil {
 			return nil, err
@@ -123,12 +139,18 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 			return nil, nil
 		}
 
-		result, err := utils.EncodeObjectWithColumnSelection(request.Query.Fields, rawResult)
+		result, err := utils.EvalNestedColumnObject(selection, rawResult)
 		if err != nil {
 			return nil, err
 		}
 		return result, nil
 	case "getArticles":
+		selection, err := queryFields.AsArray()
+		if err != nil {
+			return nil, schema.BadRequestError("the selection field type must be array", map[string]any{
+				"cause": err.Error(),
+			})
+		}
 		rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
 		if err != nil {
 			return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
@@ -151,7 +173,7 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 			return nil, schema.BadRequestError("expected not null result", nil)
 		}
 
-		result, err := utils.EncodeObjectsWithColumnSelection(request.Query.Fields, rawResult)
+		result, err := utils.EvalNestedColumnArrayIntoSlice(selection, rawResult)
 		if err != nil {
 			return nil, err
 		}

--- a/example/codegen/connector_test.go
+++ b/example/codegen/connector_test.go
@@ -48,402 +48,418 @@ func TestQueryGetTypes(t *testing.T) {
 			body: `{
 				"collection": "getTypes",
 				"arguments": {
-						"UUID": {
-								"type": "literal",
-								"value": "b085b0b9-007c-440e-9661-0d8f2de98a5a"
-						},
-						"Bool": {
-								"type": "literal",
-								"value": true
-						},
-						"String": {
-								"type": "literal",
-								"value": "hello"
-						},
-						"Int": {
-								"type": "literal",
-								"value": 1
-						},
-						"Int8": {
-								"type": "literal",
-								"value": 2
-						},
-						"Int16": {
-								"type": "literal",
-								"value": 3
-						},
-						"Int32": {
-							"type": "literal",
-							"value": 4
-						},
-						"Int64": {
-							"type": "literal",
-							"value": 5
-						},
-						"Uint": {
-							"type": "literal",
-							"value": 6
-						},
-						"Uint8": {
-							"type": "literal",
-							"value": 7
-						},
-						"Uint16": {
-							"type": "literal",
-							"value": 8
-						},
-						"Uint32": {
-							"type": "literal",
-							"value": 9
-						},
-						"Uint64": {
-							"type": "literal",
-							"value": 10
-						},
-						"Float32": {
-							"type": "literal",
-							"value": 1.1
-						},
-						"Float64": {
-							"type": "literal",
-							"value": 2.2
-						},
-						"Time": {
-							"type": "literal",
-							"value": "2024-03-05T07:00:56Z"
-						},
-						"Duration": {
-							"type": "literal",
-							"value": "10s"
-						},
-						"Text": {
-							"type": "literal",
-							"value": "text"
-						},
-						"CustomScalar": {
-							"type": "literal",
-							"value": "a comment"
-						},
-						"UUIDPtr": {
-								"type": "literal",
-								"value": "b085b0b9-007c-440e-9661-0d8f2de98a5b"
-						},
-
-						"BoolPtr": {
-							"type": "literal",
-							"value": true
-						},
-						"StringPtr": {
-								"type": "literal",
-								"value": "world"
-						},
-						"IntPtr": {
-								"type": "literal",
-								"value": 11
-						},
-						"Int8Ptr": {
-								"type": "literal",
-								"value": 12
-						},
-						"Int16Ptr": {
-								"type": "literal",
-								"value": 13
-						},
-						"Int32Ptr": {
-							"type": "literal",
-							"value": 14
-						},
-						"Int64Ptr": {
-							"type": "literal",
-							"value": 15
-						},
-						"UintPtr": {
-							"type": "literal",
-							"value": 16
-						},
-						"Uint8Ptr": {
-							"type": "literal",
-							"value": 17
-						},
-						"Uint16Ptr": {
-							"type": "literal",
-							"value": 18
-						},
-						"Uint32Ptr": {
-							"type": "literal",
-							"value": 19
-						},
-						"Uint64Ptr": {
-							"type": "literal",
-							"value": 20
-						},
-						"Float32Ptr": {
-							"type": "literal",
-							"value": 3.3
-						},
-						"Float64Ptr": {
-							"type": "literal",
-							"value": 4.4
-						},
-						"TimePtr": {
-							"type": "literal",
-							"value": "2024-03-05T07:00:00Z"
-						},
-						"DurationPtr": {
-							"type": "literal",
-							"value": "1m"
-						},
-						"TextPtr": {
-							"type": "literal",
-							"value": "text pointer"
-						},
-						"CustomScalarPtr": {
-							"type": "literal",
-							"value": "a comment pointer"
-						},
-						"Object": {
-							"type": "literal",
-							"value": {
-								"id": "b085b0b9-007c-440e-9661-0d8f2de98a5c",
-								"created_at": "2024-03-05T06:00:00Z"
-							}
-						},
-						"ObjectPtr": {
-							"type": "literal",
-							"value": {
-								"Long": 1,
-								"Lat": 2
-							}
-						},
-						"ArrayObject": {
-							"type": "literal",
-							"value": [{
-								"content": "a content"
-							}]
-						},
-						"ArrayObjectPtr": {
-							"type": "literal",
-							"value": [{"content": "a content pointer"}]
-						},
-						"NamedObject": {
-							"type": "literal",
-							"value": {
-								"id":        "1",
-								"duration":  10,
-								"created_at": "2024-03-05T05:00:00Z"
-							}
-						},
-						"NamedObjectPtr": {
-							"type": "literal",
-							"value": {
-								"id":        "2",
-								"duration":  11,
-								"created_at": "2024-03-05T04:00:00Z"
-							}
-						},
-						"NamedArray": {
-							"type": "literal",
-							"value": [{
-								"id":        "3",
-								"duration":  12,
-								"created_at": "2024-03-05T03:00:00Z"
-							}]
-						},
-						"UUIDArray": {
-							"type": "literal",
-							"value": ["b085b0b9-007c-440e-9661-0d8f2de98a5a", "b085b0b9-007c-440e-9661-0d8f2de98a5b"]
+					"UUID": {
+						"type": "literal",
+						"value": "b085b0b9-007c-440e-9661-0d8f2de98a5a"
+					},
+					"Bool": {
+						"type": "literal",
+						"value": true
+					},
+					"String": {
+						"type": "literal",
+						"value": "hello"
+					},
+					"Int": {
+						"type": "literal",
+						"value": 1
+					},
+					"Int8": {
+						"type": "literal",
+						"value": 2
+					},
+					"Int16": {
+						"type": "literal",
+						"value": 3
+					},
+					"Int32": {
+						"type": "literal",
+						"value": 4
+					},
+					"Int64": {
+						"type": "literal",
+						"value": 5
+					},
+					"Uint": {
+						"type": "literal",
+						"value": 6
+					},
+					"Uint8": {
+						"type": "literal",
+						"value": 7
+					},
+					"Uint16": {
+						"type": "literal",
+						"value": 8
+					},
+					"Uint32": {
+						"type": "literal",
+						"value": 9
+					},
+					"Uint64": {
+						"type": "literal",
+						"value": 10
+					},
+					"Float32": {
+						"type": "literal",
+						"value": 1.1
+					},
+					"Float64": {
+						"type": "literal",
+						"value": 2.2
+					},
+					"Time": {
+						"type": "literal",
+						"value": "2024-03-05T07:00:56Z"
+					},
+					"Duration": {
+						"type": "literal",
+						"value": "10s"
+					},
+					"Text": {
+						"type": "literal",
+						"value": "text"
+					},
+					"CustomScalar": {
+						"type": "literal",
+						"value": "a comment"
+					},
+					"UUIDPtr": {
+						"type": "literal",
+						"value": "b085b0b9-007c-440e-9661-0d8f2de98a5b"
+					},
+			
+					"BoolPtr": {
+						"type": "literal",
+						"value": true
+					},
+					"StringPtr": {
+						"type": "literal",
+						"value": "world"
+					},
+					"IntPtr": {
+						"type": "literal",
+						"value": 11
+					},
+					"Int8Ptr": {
+						"type": "literal",
+						"value": 12
+					},
+					"Int16Ptr": {
+						"type": "literal",
+						"value": 13
+					},
+					"Int32Ptr": {
+						"type": "literal",
+						"value": 14
+					},
+					"Int64Ptr": {
+						"type": "literal",
+						"value": 15
+					},
+					"UintPtr": {
+						"type": "literal",
+						"value": 16
+					},
+					"Uint8Ptr": {
+						"type": "literal",
+						"value": 17
+					},
+					"Uint16Ptr": {
+						"type": "literal",
+						"value": 18
+					},
+					"Uint32Ptr": {
+						"type": "literal",
+						"value": 19
+					},
+					"Uint64Ptr": {
+						"type": "literal",
+						"value": 20
+					},
+					"Float32Ptr": {
+						"type": "literal",
+						"value": 3.3
+					},
+					"Float64Ptr": {
+						"type": "literal",
+						"value": 4.4
+					},
+					"TimePtr": {
+						"type": "literal",
+						"value": "2024-03-05T07:00:00Z"
+					},
+					"DurationPtr": {
+						"type": "literal",
+						"value": "1m"
+					},
+					"TextPtr": {
+						"type": "literal",
+						"value": "text pointer"
+					},
+					"CustomScalarPtr": {
+						"type": "literal",
+						"value": "a comment pointer"
+					},
+					"Object": {
+						"type": "literal",
+						"value": {
+							"id": "b085b0b9-007c-440e-9661-0d8f2de98a5c",
+							"created_at": "2024-03-05T06:00:00Z"
 						}
+					},
+					"ObjectPtr": {
+						"type": "literal",
+						"value": {
+							"Long": 1,
+							"Lat": 2
+						}
+					},
+					"ArrayObject": {
+						"type": "literal",
+						"value": [
+							{
+								"content": "a content"
+							}
+						]
+					},
+					"ArrayObjectPtr": {
+						"type": "literal",
+						"value": [{ "content": "a content pointer" }]
+					},
+					"NamedObject": {
+						"type": "literal",
+						"value": {
+							"id": "1",
+							"duration": 10,
+							"created_at": "2024-03-05T05:00:00Z"
+						}
+					},
+					"NamedObjectPtr": {
+						"type": "literal",
+						"value": {
+							"id": "2",
+							"duration": 11,
+							"created_at": "2024-03-05T04:00:00Z"
+						}
+					},
+					"NamedArray": {
+						"type": "literal",
+						"value": [
+							{
+								"id": "3",
+								"duration": 12,
+								"created_at": "2024-03-05T03:00:00Z"
+							}
+						]
+					},
+					"UUIDArray": {
+						"type": "literal",
+						"value": [
+							"b085b0b9-007c-440e-9661-0d8f2de98a5a",
+							"b085b0b9-007c-440e-9661-0d8f2de98a5b"
+						]
+					}
 				},
 				"query": {
-						"fields": {
-								"UUID": {
+					"fields": {
+						"__value": {
+							"type": "column",
+							"column": "__value",
+							"fields": {
+								"type": "object",
+								"fields": {
+									"UUID": {
 										"type": "column",
 										"column": "UUID"
-								},
-								"Bool": {
+									},
+									"Bool": {
 										"type": "column",
 										"column": "Bool"
-								},
-								"String": {
+									},
+									"String": {
 										"type": "column",
 										"column": "String"
-								},
-								"Int": {
+									},
+									"Int": {
 										"type": "column",
 										"column": "Int"
-								},
-								"Int8": {
+									},
+									"Int8": {
 										"type": "column",
 										"column": "Int8"
-								},
-								"Int16": {
+									},
+									"Int16": {
 										"type": "column",
 										"column": "Int16"
-								},
-								"Int32": {
+									},
+									"Int32": {
 										"type": "column",
 										"column": "Int32"
-								},
-								"Int64": {
+									},
+									"Int64": {
 										"type": "column",
 										"column": "Int64"
-								},
-								"Uint": {
+									},
+									"Uint": {
 										"type": "column",
 										"column": "Uint"
-								},
-								"Uint8": {
+									},
+									"Uint8": {
 										"type": "column",
 										"column": "Uint8"
-								},
-								"Uint16": {
+									},
+									"Uint16": {
 										"type": "column",
 										"column": "Uint16"
-								},
-								"Uint32": {
+									},
+									"Uint32": {
 										"type": "column",
 										"column": "Uint32"
-								},
-								"Uint64": {
+									},
+									"Uint64": {
 										"type": "column",
 										"column": "Uint64"
-								},
-								"Float32": {
+									},
+									"Float32": {
 										"type": "column",
 										"column": "Float32"
-								},
-								"Float64": {
+									},
+									"Float64": {
 										"type": "column",
 										"column": "Float64"
-								},
-								"Time": {
+									},
+									"Time": {
 										"type": "column",
 										"column": "Time"
-								},
-								"Duration": {
+									},
+									"Duration": {
 										"type": "column",
 										"column": "Duration"
-								},
-								"Text": {
-									"type": "column",
-									"column": "Text"
-								},
-								"CustomScalar": {
-									"type": "column",
-									"column": "CustomScalar"
-								},
-								"UUIDPtr": {
+									},
+									"Text": {
+										"type": "column",
+										"column": "Text"
+									},
+									"CustomScalar": {
+										"type": "column",
+										"column": "CustomScalar"
+									},
+									"UUIDPtr": {
 										"type": "column",
 										"column": "UUIDPtr"
-								},
-								"BoolPtr": {
+									},
+									"BoolPtr": {
 										"type": "column",
 										"column": "BoolPtr"
-								},
-								"StringPtr": {
+									},
+									"StringPtr": {
 										"type": "column",
 										"column": "StringPtr"
-								},
-								"IntPtr": {
+									},
+									"IntPtr": {
 										"type": "column",
 										"column": "IntPtr"
-								},
-								"Int8Ptr": {
+									},
+									"Int8Ptr": {
 										"type": "column",
 										"column": "Int8Ptr"
-								},
-								"Int16Ptr": {
+									},
+									"Int16Ptr": {
 										"type": "column",
 										"column": "Int16Ptr"
-								},
-								"Int32Ptr": {
+									},
+									"Int32Ptr": {
 										"type": "column",
 										"column": "Int32Ptr"
-								},
-								"Int64Ptr": {
+									},
+									"Int64Ptr": {
 										"type": "column",
 										"column": "Int64Ptr"
-								},
-								"UintPtr": {
+									},
+									"UintPtr": {
 										"type": "column",
 										"column": "UintPtr"
-								},
-								"Uint8Ptr": {
+									},
+									"Uint8Ptr": {
 										"type": "column",
 										"column": "Uint8Ptr"
-								},
-								"Uint16Ptr": {
+									},
+									"Uint16Ptr": {
 										"type": "column",
 										"column": "Uint16Ptr"
-								},
-								"Uint32Ptr": {
+									},
+									"Uint32Ptr": {
 										"type": "column",
 										"column": "Uint32Ptr"
-								},
-								"Uint64Ptr": {
+									},
+									"Uint64Ptr": {
 										"type": "column",
 										"column": "Uint64Ptr"
-								},
-								"Float32Ptr": {
+									},
+									"Float32Ptr": {
 										"type": "column",
 										"column": "Float32Ptr"
-								},
-								"Float64Ptr": {
+									},
+									"Float64Ptr": {
 										"type": "column",
 										"column": "Float64Ptr"
-								},
-								"TimePtr": {
+									},
+									"TimePtr": {
 										"type": "column",
 										"column": "TimePtr"
-								},
-								"DurationPtr": {
+									},
+									"DurationPtr": {
 										"type": "column",
 										"column": "DurationPtr"
-								},
-								"TextPtr": {
-									"type": "column",
-									"column": "TextPtr"
-								},
-								"CustomScalarPtr": {
-									"type": "column",
-									"column": "CustomScalarPtr"
-								},
-								"Object": {
-									"type": "column",
-									"column": "Object"
-								},
-								"ObjectPtr": {
-									"type": "column",
-									"column": "ObjectPtr"
-								},
-								"ArrayObject": {
-									"type": "column",
-									"column": "ArrayObject"
-								},
-								"ArrayObjectPtr": {
-									"type": "column",
-									"column": "ArrayObjectPtr"
-								},
-								"NamedObject": {
-									"type": "column",
-									"column": "NamedObject"
-								},
-								"NamedObjectPtr": {
-									"type": "column",
-									"column": "NamedObjectPtr"
-								},
-								"NamedArray": {
-									"type": "column",
-									"column": "NamedArray"
-								},
-								"UUIDArray": {
-									"type": "column",
-									"column": "UUIDArray"
+									},
+									"TextPtr": {
+										"type": "column",
+										"column": "TextPtr"
+									},
+									"CustomScalarPtr": {
+										"type": "column",
+										"column": "CustomScalarPtr"
+									},
+									"Object": {
+										"type": "column",
+										"column": "Object"
+									},
+									"ObjectPtr": {
+										"type": "column",
+										"column": "ObjectPtr"
+									},
+									"ArrayObject": {
+										"type": "column",
+										"column": "ArrayObject"
+									},
+									"ArrayObjectPtr": {
+										"type": "column",
+										"column": "ArrayObjectPtr"
+									},
+									"NamedObject": {
+										"type": "column",
+										"column": "NamedObject"
+									},
+									"NamedObjectPtr": {
+										"type": "column",
+										"column": "NamedObjectPtr"
+									},
+									"NamedArray": {
+										"type": "column",
+										"column": "NamedArray"
+									},
+									"UUIDArray": {
+										"type": "column",
+										"column": "UUIDArray"
+									}
 								}
+							}
 						}
+					}
 				},
 				"collection_relationships": {}
-		}`,
+			}`,
 			response: functions.GetTypesArguments{
 				UUID:            uuid.MustParse("b085b0b9-007c-440e-9661-0d8f2de98a5a"),
 				Bool:            true,
@@ -572,19 +588,22 @@ func TestQueries(t *testing.T) {
 			status: http.StatusOK,
 			body: `{
 				"collection": "hello",
-				"arguments": {},
 				"query": {
 					"fields": {
-						"num": {
+						"__value": {
 							"type": "column",
-							"column": "num"
-						},
-						"text": {
-							"type": "column",
-							"column": "text"
+							"column": "__value",
+							"fields": {
+								"type": "object",
+								"fields": {
+									"num": { "type": "column", "column": "num", "fields": null },
+									"text": { "type": "column", "column": "text", "fields": null }
+								}
+							}
 						}
 					}
 				},
+				"arguments": {},
 				"collection_relationships": {}
 			}`,
 			response: `{
@@ -593,15 +612,110 @@ func TestQueries(t *testing.T) {
 			}`,
 		},
 		{
+			name:   "hello_failure_array",
+			status: http.StatusBadRequest,
+			body: `{
+				"collection": "hello",
+				"query": {
+					"fields": {
+						"__value": {
+							"type": "column",
+							"column": "__value",
+							"fields": {
+								"type": "array",
+								"fields": {
+									"type": "object",
+									"fields": {
+										"num": { "type": "column", "column": "num", "fields": null },
+										"text": { "type": "column", "column": "text", "fields": null }
+									}
+								}
+							}
+						}
+					}
+				},
+				"arguments": {},
+				"collection_relationships": {}
+			}`,
+			errorMsg: "the selection field type must be object",
+		},
+		{
 			name:   "getBool",
 			status: http.StatusOK,
 			body: `{
 				"collection": "getBool",
 				"arguments": {},
-				"query": {},
+				"query": {
+					"fields": {
+						"__value": {
+							"type": "column",
+							"column": "__value",
+							"fields": null
+						}
+					}
+				},
 				"collection_relationships": {}
 			}`,
 			response: `true`,
+		},
+		{
+			name:   "getArticles_failure_object",
+			status: http.StatusBadRequest,
+			body: `{
+				"collection": "getArticles",
+				"query": {
+					"fields": {
+						"__value": {
+							"type": "column",
+							"column": "__value",
+							"fields": {
+								"type": "object",
+								"fields": {
+									"num": { "type": "column", "column": "num", "fields": null },
+									"text": { "type": "column", "column": "text", "fields": null }
+								}
+							}
+						}
+					}
+				},
+				"arguments": {},
+				"collection_relationships": {}
+			}`,
+			errorMsg: "the selection field type must be array",
+		},
+		{
+			name:   "getArticles_success",
+			status: http.StatusOK,
+			body: `{
+				"collection": "getArticles",
+				"query": {
+					"fields": {
+						"__value": {
+							"type": "column",
+							"column": "__value",
+							"fields": {
+								"type": "array",
+								"fields": {
+									"type": "object",
+									"fields": {
+										"id": { "type": "column", "column": "id" }
+									}
+								}
+							}
+						}
+					}
+				},
+				"arguments": {
+					"Limit": {
+						"type": "literal",
+						"value": 1
+					}
+				},
+				"collection_relationships": {}
+			}`,
+			response: `[{
+				"id": "1"
+			}]`,
 		},
 	}
 


### PR DESCRIPTION
- Fix function query selection evaluation with nested `__value` field.
- Improve OTEL propagator and extract `traceparent` context from headers.
- Print request body logs when the log level <= debug. 