### PR TITLE
Extend CLI interface and add context to ParseConfiguration and  TryInitState methods

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           only-new-issues: true
           skip-cache: true
       - name: Run Go unit tests for the SDK
-        run: | 
+        run: |
           rm cmd/ndc-go-sdk/go.mod
           rm cmd/ndc-go-sdk/go.sum
           go mod tidy
@@ -73,7 +73,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: "20 70"
+          thresholds: "50 70"
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,7 +73,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: "50 70"
+          thresholds: "40 70"
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: ${{ github.event_name == 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ Other configurations are inherited from the [OpenTelemetry Go SDK](https://githu
 
 Prometheus metrics are exported via the `/metrics` endpoint.
 
+## Customize the CLI
+
+The SDK uses [Kong](https://github.com/alecthomas/kong), a lightweight command-line parser to implement the CLI interface.
+
+The default CLI already implements the `serve` command, so you don't need to do anything. However, it's also easy to extend if you want to add more custom commands.
+
+The SDK abstracts an interface for the CLI that requires embedding the base `ServeCLI` command and can execute other commands.
+
+```go
+type ConnectorCLI interface {
+	GetServeCLI() *ServeCLI
+	Execute(ctx context.Context, command string) error
+}
+```
+
+And use the `StartCustom` function to start the CLI.
+
+See the [custom CLI example](./example/reference/main.go) in the reference connector.
+
 ## Regenerating Schema Types
 
 The NDC spec types are borrowed from ndc-sdk-typescript that are generated from the NDC Spec Rust types.

--- a/cmd/ndc-go-sdk/main.go
+++ b/cmd/ndc-go-sdk/main.go
@@ -28,7 +28,7 @@ var cli struct {
 }
 
 func main() {
-	cmd := kong.Parse(&cli)
+	cmd := kong.Parse(&cli, kong.UsageOnError())
 	switch cmd.Command() {
 	case "new":
 		setupGlobalLogger(cli.New.LogLevel)

--- a/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
@@ -24,7 +24,7 @@ func init() {
 }
 
 // GetSchema gets the connector's schema.
-func (c *Connector) GetSchema(configuration *types.Configuration, _ *types.State) (*schema.SchemaResponse, error) {
+func (c *Connector) GetSchema(ctx context.Context, configuration *types.Configuration, _ *types.State) (*schema.SchemaResponse, error) {
   return &schemaResponse, nil
 }
 

--- a/cmd/ndc-go-sdk/templates/new/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/templates/new/connector.go.tmpl
@@ -13,7 +13,7 @@ type Connector struct{}
 
 // ParseConfiguration validates the configuration files provided by the user, returning a validated 'Configuration',
 // or throwing an error to prevents Connector startup.
-func (connector *Connector) ParseConfiguration(configurationDir string) (*types.Configuration, error) {
+func (connector *Connector) ParseConfiguration(ctx context.Context, configurationDir string) (*types.Configuration, error) {
 	return &types.Configuration{}, nil
 }
 
@@ -24,7 +24,7 @@ func (connector *Connector) ParseConfiguration(configurationDir string) (*types.
 //
 // In addition, this function should register any
 // connector-specific metrics with the metrics registry.
-func (connector *Connector) TryInitState(configuration *types.Configuration, metrics *connector.TelemetryState) (*types.State, error) {
+func (connector *Connector) TryInitState(ctx context.Context, configuration *types.Configuration, metrics *connector.TelemetryState) (*types.State, error) {
 	return &types.State{}, nil
 }
 

--- a/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
@@ -19,7 +19,7 @@ func init() {
   }
 }
 // GetSchema gets the connector's schema.
-func (c *Connector) GetSchema(configuration *types.Configuration, _ *types.State) (*schema.SchemaResponse, error) {
+func (c *Connector) GetSchema(ctx context.Context, configuration *types.Configuration, _ *types.State) (*schema.SchemaResponse, error) {
   return &schemaResponse, nil
 }
 // Query executes a query.

--- a/connector/cli.go
+++ b/connector/cli.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/alecthomas/kong"
@@ -8,18 +9,38 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var cli struct {
-	Serve struct {
-		Configuration       string `help:"Configuration directory." env:"HASURA_CONFIGURATION_DIRECTORY"`
-		Port                uint   `help:"Serve Port." env:"HASURA_CONNECTOR_PORT" default:"8080"`
-		ServiceTokenSecret  string `help:"Service token secret." env:"HASURA_SERVICE_TOKEN_SECRET"`
-		OtlpEndpoint        string `help:"OpenTelemetry receiver endpoint that is set as default for all types." env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-		OtlpTracesEndpoint  string `help:"OpenTelemetry endpoint for traces." env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
-		OtlpInsecure        bool   `help:"Disable LTS for OpenTelemetry gRPC exporters." env:"OTEL_EXPORTER_OTLP_INSECURE"`
-		OtlpMetricsEndpoint string `help:"OpenTelemetry endpoint for metrics." env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
-		ServiceName         string `help:"OpenTelemetry service name." env:"OTEL_SERVICE_NAME"`
-		LogLevel            string `help:"Log level." env:"HASURA_LOG_LEVEL" enum:"trace,debug,info,warn,error" default:"info"`
-	} `cmd:"" help:"Serve the NDC connector."`
+// ServeCommandArguments contains argument flags of the serve command
+type ServeCommandArguments struct {
+	Configuration       string `help:"Configuration directory." env:"HASURA_CONFIGURATION_DIRECTORY"`
+	Port                uint   `help:"Serve Port." env:"HASURA_CONNECTOR_PORT" default:"8080"`
+	ServiceTokenSecret  string `help:"Service token secret." env:"HASURA_SERVICE_TOKEN_SECRET"`
+	OtlpEndpoint        string `help:"OpenTelemetry receiver endpoint that is set as default for all types." env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	OtlpTracesEndpoint  string `help:"OpenTelemetry endpoint for traces." env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
+	OtlpInsecure        bool   `help:"Disable LTS for OpenTelemetry gRPC exporters." env:"OTEL_EXPORTER_OTLP_INSECURE"`
+	OtlpMetricsEndpoint string `help:"OpenTelemetry endpoint for metrics." env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
+	ServiceName         string `help:"OpenTelemetry service name." env:"OTEL_SERVICE_NAME"`
+}
+
+// ServeCLI is used for CLI argument binding
+type ServeCLI struct {
+	LogLevel string                `help:"Log level." env:"HASURA_LOG_LEVEL" enum:"trace,debug,info,warn,error" default:"info"`
+	Serve    ServeCommandArguments `cmd:"" help:"Serve the NDC connector."`
+}
+
+// GetServeCLI returns the inner serve cli
+func (cli *ServeCLI) GetServeCLI() *ServeCLI {
+	return cli
+}
+
+// Execute executes the command
+func (cli *ServeCLI) Execute(ctx context.Context, command string) error {
+	return fmt.Errorf("unknown command <%s>", command)
+}
+
+// ConnectorCLI abstracts the connector CLI so NDC authors can extend it
+type ConnectorCLI interface {
+	GetServeCLI() *ServeCLI
+	Execute(ctx context.Context, command string) error
 }
 
 // Starts the connector.
@@ -27,29 +48,40 @@ var cli struct {
 //
 // This should be the entrypoint of your connector
 func Start[Configuration any, State any](connector Connector[Configuration, State], options ...ServeOption) error {
-	cmd := kong.Parse(&cli)
-	switch cmd.Command() {
-	case "serve":
-		logger, err := initLogger(cli.Serve.LogLevel)
-		if err != nil {
-			return err
-		}
+	var cli ServeCLI
+	return StartCustom[Configuration, State](&cli, connector)
+}
 
+// Starts the connector with custom CLI.
+// Will read command line arguments or environment variables to determine runtime configuration.
+//
+// This should be the entrypoint of your connector
+func StartCustom[Configuration any, State any](cli ConnectorCLI, connector Connector[Configuration, State], options ...ServeOption) error {
+	cmd := kong.Parse(cli, kong.UsageOnError())
+	serveCLI := cli.GetServeCLI()
+	command := cmd.Command()
+	logger, err := initLogger(serveCLI.LogLevel)
+	if err != nil {
+		return err
+	}
+	switch command {
+	case "serve":
 		server, err := NewServer[Configuration, State](connector, &ServerOptions{
-			Configuration:       cli.Serve.Configuration,
-			ServiceTokenSecret:  cli.Serve.ServiceTokenSecret,
-			OTLPEndpoint:        cli.Serve.OtlpEndpoint,
-			OTLPInsecure:        cli.Serve.OtlpInsecure,
-			OTLPTracesEndpoint:  cli.Serve.OtlpTracesEndpoint,
-			OTLPMetricsEndpoint: cli.Serve.OtlpMetricsEndpoint,
-			ServiceName:         cli.Serve.ServiceName,
+			Configuration:       serveCLI.Serve.Configuration,
+			ServiceTokenSecret:  serveCLI.Serve.ServiceTokenSecret,
+			OTLPEndpoint:        serveCLI.Serve.OtlpEndpoint,
+			OTLPInsecure:        serveCLI.Serve.OtlpInsecure,
+			OTLPTracesEndpoint:  serveCLI.Serve.OtlpTracesEndpoint,
+			OTLPMetricsEndpoint: serveCLI.Serve.OtlpMetricsEndpoint,
+			ServiceName:         serveCLI.Serve.ServiceName,
 		}, append(options, WithLogger(*logger))...)
 		if err != nil {
 			return err
 		}
-		return server.ListenAndServe(cli.Serve.Port)
+		return server.ListenAndServe(serveCLI.Serve.Port)
 	default:
-		return fmt.Errorf("unknown command <%s>", cmd.Command())
+		ctx := context.WithValue(context.Background(), logContextKey, logger)
+		return cli.Execute(ctx, command)
 	}
 }
 

--- a/connector/server_test.go
+++ b/connector/server_test.go
@@ -111,12 +111,12 @@ var mockSchema = schema.SchemaResponse{
 	},
 }
 
-func (mc *mockConnector) ParseConfiguration(configurationDir string) (*mockConfiguration, error) {
+func (mc *mockConnector) ParseConfiguration(ctx context.Context, configurationDir string) (*mockConfiguration, error) {
 	return &mockConfiguration{
 		Version: 1,
 	}, nil
 }
-func (mc *mockConnector) TryInitState(configuration *mockConfiguration, metrics *TelemetryState) (*mockState, error) {
+func (mc *mockConnector) TryInitState(ctx context.Context, configuration *mockConfiguration, metrics *TelemetryState) (*mockState, error) {
 	return &mockState{}, nil
 }
 
@@ -128,7 +128,7 @@ func (mc *mockConnector) GetCapabilities(configuration *mockConfiguration) *sche
 	return &mockCapabilities
 }
 
-func (mc *mockConnector) GetSchema(configuration *mockConfiguration, state *mockState) (*schema.SchemaResponse, error) {
+func (mc *mockConnector) GetSchema(ctx context.Context, configuration *mockConfiguration, state *mockState) (*schema.SchemaResponse, error) {
 	return &mockSchema, nil
 }
 func (mc *mockConnector) QueryExplain(ctx context.Context, configuration *mockConfiguration, state *mockState, request *schema.QueryRequest) (*schema.ExplainResponse, error) {

--- a/connector/types.go
+++ b/connector/types.go
@@ -15,7 +15,7 @@ type Connector[Configuration any, State any] interface {
 
 	// ParseConfiguration validates the configuration files provided by the user, returning a validated 'Configuration',
 	// or throwing an error to prevents Connector startup.
-	ParseConfiguration(configurationDir string) (*Configuration, error)
+	ParseConfiguration(ctx context.Context, configurationDir string) (*Configuration, error)
 
 	// TryInitState initializes the connector's in-memory state.
 	//
@@ -24,7 +24,7 @@ type Connector[Configuration any, State any] interface {
 	//
 	// In addition, this function should register any
 	// connector-specific metrics with the metrics registry.
-	TryInitState(configuration *Configuration, metrics *TelemetryState) (*State, error)
+	TryInitState(ctx context.Context, configuration *Configuration, metrics *TelemetryState) (*State, error)
 
 	// HealthCheck checks the health of the connector.
 	//
@@ -48,7 +48,7 @@ type Connector[Configuration any, State any] interface {
 	// This function implements the [schema endpoint] from the NDC specification.
 	//
 	// [schema endpoint]: https://hasura.github.io/ndc-spec/specification/schema/index.html
-	GetSchema(configuration *Configuration, state *State) (*schema.SchemaResponse, error)
+	GetSchema(ctx context.Context, configuration *Configuration, state *State) (*schema.SchemaResponse, error)
 
 	// QueryExplain explains a query by creating an execution plan.
 	// This function implements the [explain endpoint] from the NDC specification.

--- a/example/codegen/connector.generated.go
+++ b/example/codegen/connector.generated.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 // GetSchema gets the connector's schema.
-func (c *Connector) GetSchema(configuration *types.Configuration, _ *types.State) (*schema.SchemaResponse, error) {
+func (c *Connector) GetSchema(ctx context.Context, configuration *types.Configuration, _ *types.State) (*schema.SchemaResponse, error) {
 	return &schemaResponse, nil
 }
 

--- a/example/codegen/connector.go
+++ b/example/codegen/connector.go
@@ -13,7 +13,7 @@ type Connector struct{}
 
 // ParseConfiguration validates the configuration files provided by the user, returning a validated 'Configuration',
 // or throwing an error to prevents Connector startup.
-func (connector *Connector) ParseConfiguration(configurationDir string) (*types.Configuration, error) {
+func (connector *Connector) ParseConfiguration(ctx context.Context, configurationDir string) (*types.Configuration, error) {
 	return &types.Configuration{}, nil
 }
 
@@ -24,7 +24,7 @@ func (connector *Connector) ParseConfiguration(configurationDir string) (*types.
 //
 // In addition, this function should register any
 // connector-specific metrics with the metrics registry.
-func (connector *Connector) TryInitState(configuration *types.Configuration, metrics *connector.TelemetryState) (*types.State, error) {
+func (connector *Connector) TryInitState(ctx context.Context, configuration *types.Configuration, metrics *connector.TelemetryState) (*types.State, error) {
 	return &types.State{}, nil
 }
 

--- a/example/reference/connector.go
+++ b/example/reference/connector.go
@@ -72,10 +72,10 @@ func (s *State) GetLatestArticle() *Article {
 
 type Connector struct{}
 
-func (mc *Connector) ParseConfiguration(rawConfiguration string) (*Configuration, error) {
+func (mc *Connector) ParseConfiguration(ctx context.Context, rawConfiguration string) (*Configuration, error) {
 	return &Configuration{}, nil
 }
-func (mc *Connector) TryInitState(configuration *Configuration, metrics *connector.TelemetryState) (*State, error) {
+func (mc *Connector) TryInitState(ctx context.Context, configuration *Configuration, metrics *connector.TelemetryState) (*State, error) {
 	articles, err := readArticles()
 
 	if err != nil {
@@ -126,7 +126,7 @@ func (mc *Connector) GetCapabilities(configuration *Configuration) *schema.Capab
 	}
 }
 
-func (mc *Connector) GetSchema(configuration *Configuration, state *State) (*schema.SchemaResponse, error) {
+func (mc *Connector) GetSchema(ctx context.Context, configuration *Configuration, state *State) (*schema.SchemaResponse, error) {
 	return &schema.SchemaResponse{
 		ScalarTypes: schema.SchemaResponseScalarTypes{
 			"Int": schema.ScalarType{

--- a/example/reference/main.go
+++ b/example/reference/main.go
@@ -1,13 +1,36 @@
 package main
 
-import "github.com/hasura/ndc-sdk-go/connector"
+import (
+	"context"
+	"fmt"
+
+	"github.com/hasura/ndc-sdk-go/connector"
+)
 
 func main() {
-	if err := connector.Start[Configuration, State](
+	var cli CLI
+	if err := connector.StartCustom[Configuration, State](
+		&cli,
 		&Connector{},
 		connector.WithMetricsPrefix("ndc_ref"),
 		connector.WithDefaultServiceName("ndc_ref"),
 	); err != nil {
 		panic(err)
+	}
+}
+
+type CLI struct {
+	connector.ServeCLI
+	Version struct{} `cmd:"" help:"Print the version."`
+}
+
+func (cli *CLI) Execute(ctx context.Context, command string) error {
+	logger := connector.GetLogger(ctx)
+	switch command {
+	case "version":
+		logger.Info().Msg("v0.1.0")
+		return nil
+	default:
+		return fmt.Errorf("unknown command <%s>", command)
 	}
 }


### PR DESCRIPTION
Change the Connector interface with context.Context added:

```go
ParseConfiguration(ctx context.Context, configurationDir string) (*Configuration, error)
TryInitState(ctx context.Context, configuration *Configuration, metrics *TelemetryState) (*State, error)
```  

The PR also exposes the CLI interface to be extendable. See [README](https://github.com/hasura/ndc-sdk-go/pull/31/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)