### PR TITLE
fix invalid capabilities version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OUTPUT_DIR := _output
 typegen:
 	cd typegen && ./regenerate-schema.sh
 
-.PHONY: typegen
+.PHONY: format
 format:
 	gofmt -w -s .
 
@@ -29,7 +29,7 @@ build-codegen:
 	cd ./cmd/ndc-go-sdk && go build -o ../../_output/hasura-ndc-go .
 	
 # build the build-codegen cli for all given platform/arch
-.PHONY: build-codegen
+.PHONY: ci-build-codegen
 ci-build-codegen: export CGO_ENABLED=0
 ci-build-codegen: clean
 	cd ./cmd/ndc-go-sdk && \

--- a/cmd/ndc-go-sdk/templates/new/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/templates/new/connector.go.tmpl
@@ -41,7 +41,7 @@ func (mc *Connector) HealthCheck(ctx context.Context, configuration *types.Confi
 // GetCapabilities get the connector's capabilities.
 func (mc *Connector) GetCapabilities(configuration *types.Configuration) *schema.CapabilitiesResponse {
 	return &schema.CapabilitiesResponse{
-		Version: "^0.1.0",
+		Version: "0.1.0",
 		Capabilities: schema.Capabilities{
 			Query: schema.QueryCapabilities{
 				Variables: schema.LeafCapability{},

--- a/example/codegen/connector.go
+++ b/example/codegen/connector.go
@@ -41,7 +41,7 @@ func (mc *Connector) HealthCheck(ctx context.Context, configuration *types.Confi
 // GetCapabilities get the connector's capabilities.
 func (mc *Connector) GetCapabilities(configuration *types.Configuration) *schema.CapabilitiesResponse {
 	return &schema.CapabilitiesResponse{
-		Version: "^0.1.0",
+		Version: "0.1.0",
 		Capabilities: schema.Capabilities{
 			Query: schema.QueryCapabilities{
 				Variables: schema.LeafCapability{},

--- a/example/reference/connector.go
+++ b/example/reference/connector.go
@@ -112,7 +112,7 @@ func (mc *Connector) HealthCheck(ctx context.Context, configuration *Configurati
 
 func (mc *Connector) GetCapabilities(configuration *Configuration) *schema.CapabilitiesResponse {
 	return &schema.CapabilitiesResponse{
-		Version: "^0.1.0",
+		Version: "0.1.0",
 		Capabilities: schema.Capabilities{
 			Query: schema.QueryCapabilities{
 				Aggregates: schema.LeafCapability{},


### PR DESCRIPTION
The `ndc-test` tool doesn't support semver with `^`. The PR removes it from the generator.