### PR TITLE
add more OTEL configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,24 @@ Commands:
     Serve the NDC connector.
 
     Flags:
-      --configuration=STRING            Configuration directory ($HASURA_CONFIGURATION_DIRECTORY).
-      --port=8080                       Serve Port ($HASURA_CONNECTOR_PORT).
-      --service-token-secret=STRING     Service token secret ($HASURA_SERVICE_TOKEN_SECRET).
-      --otlp-endpoint=STRING            OpenTelemetry receiver endpoint that is set as default for all types ($OTEL_EXPORTER_OTLP_ENDPOINT).
-      --otlp-traces-endpoint=STRING     OpenTelemetry endpoint for traces ($OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).
-      --otlp-insecure                   Disable LTS for OpenTelemetry gRPC exporters ($OTEL_EXPORTER_OTLP_INSECURE).
-      --otlp-metrics-endpoint=STRING    OpenTelemetry endpoint for metrics ($OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).
-      --service-name=STRING             OpenTelemetry service name ($OTEL_SERVICE_NAME).
-      --log-level="info"                Log level ($HASURA_LOG_LEVEL).
+      --service-name=STRING                OpenTelemetry service name ($OTEL_SERVICE_NAME).
+      --otlp-endpoint=STRING               OpenTelemetry receiver endpoint that is set as default for all types ($OTEL_EXPORTER_OTLP_ENDPOINT).
+      --otlp-traces-endpoint=STRING        OpenTelemetry endpoint for traces ($OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).
+      --otlp-metrics-endpoint=STRING       OpenTelemetry endpoint for metrics ($OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).
+      --otlp-insecure                      Disable LTS for OpenTelemetry exporters ($OTEL_EXPORTER_OTLP_INSECURE).
+      --otlp-traces-insecure               Disable LTS for OpenTelemetry traces exporter ($OTEL_EXPORTER_OTLP_TRACES_INSECURE).
+      --otlp-metrics-insecure              Disable LTS for OpenTelemetry metrics exporter ($OTEL_EXPORTER_OTLP_METRICS_INSECURE).
+      --otlp-protocol=STRING               OpenTelemetry receiver protocol for all types ($OTEL_EXPORTER_OTLP_PROTOCOL).
+      --otlp-traces-protocol=STRING        OpenTelemetry receiver protocol for traces ($OTEL_EXPORTER_OTLP_TRACES_PROTOCOL).
+      --otlp-metrics-protocol=STRING       OpenTelemetry receiver protocol for metrics ($OTEL_EXPORTER_OTLP_METRICS_PROTOCOL).
+      --otlp-compression="gzip"            Enable compression for OTLP exporters. Accept: none, gzip ($OTEL_EXPORTER_OTLP_COMPRESSION)
+      --otlp-trace-compression="gzip"      Enable compression for OTLP traces exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_TRACES_COMPRESSION)
+      --otlp-metrics-compression="gzip"    Enable compression for OTLP metrics exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_METRICS_COMPRESSION).
+      --metrics-exporter="none"            Metrics export type. Accept: none, otlp, prometheus ($OTEL_METRICS_EXPORTER).
+      --prometheus-port=PROMETHEUS-PORT    Prometheus port for the Prometheus HTTP server. Use /metrics endpoint of the connector server if empty ($OTEL_EXPORTER_PROMETHEUS_PORT)
+      --configuration=STRING               Configuration directory ($HASURA_CONFIGURATION_DIRECTORY).
+      --port=8080                          Serve Port ($HASURA_CONNECTOR_PORT).
+      --service-token-secret=STRING        Service token secret ($HASURA_SERVICE_TOKEN_SECRET).
 ```
 
 Please refer to the [NDC Spec](https://hasura.github.io/ndc-spec/) for details on implementing the Connector interface, or see [examples](./example).
@@ -66,18 +75,21 @@ Please refer to the [NDC Spec](https://hasura.github.io/ndc-spec/) for details o
 
 ### OpenTelemetry
 
-OpenTelemetry exporter is disabled by default unless one of `--otlp-endpoint`, `--otlp-traces-endpoint` or `--otlp-metrics-endpoint` argument is set. The SDK automatically detects either HTTP or gRPC protocol by the URL scheme. For example:
+OpenTelemetry exporter is disabled by default unless one of `--otlp-endpoint`, `--otlp-traces-endpoint` or `--otlp-metrics-endpoint` argument is set. By default, the SDK treats port `4318` as HTTP protocol and gRPC protocol for others.
 
-- `http://localhost:4318`: HTTP
-- `localhost:4317`: gRPC
-
-The SDK can also detect TLS connections via http(s). However, if you want to disable TLS for gRPC, you must add `--otlp-insecure` the flag.
+If `--otlp-*insecure` flags are not set, the SDK can also detect TLS connections via http(s).
 
 Other configurations are inherited from the [OpenTelemetry Go SDK](https://github.com/open-telemetry/opentelemetry-go). See [Environment Variable Specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) and [OTLP Exporter Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/).
 
-### Prometheus
+### Metrics
 
-Prometheus metrics are exported via the `/metrics` endpoint.
+The SDK supports OTLP and Prometheus metrics exporters that is enabled by `--metrics-exporter` (`OTEL_METRICS_EXPORTER`) flag. Supported values:
+
+- `none` (default): disable the exporter
+- `otlp`: OTLP exporter
+- `prometheus`: Prometheus exporter via the `/metrics` endpoint.
+
+Prometheus exporter is served in the same HTTP server with the connector. If you want to run it on another port, configure the `--prometheus-port` (`OTEL_EXPORTER_PROMETHEUS_PORT`) flag.
 
 ## Customize the CLI
 

--- a/cmd/ndc-go-sdk/connector.go
+++ b/cmd/ndc-go-sdk/connector.go
@@ -158,13 +158,13 @@ func genConnectorFunctions(rawSchema *RawConnectorSchema) string {
 		if fn.ResultType.IsScalar {
 			sb.WriteString(`
     if len(queryFields) > 0 {
-      return nil, schema.BadRequestError("cannot evaluate selection fields for scalar", nil)
+      return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
     }`)
 		} else if fn.ResultType.IsArray {
 			sb.WriteString(`
     selection, err := queryFields.AsArray()
     if err != nil {
-      return nil, schema.BadRequestError("the selection field type must be array", map[string]any{
+      return nil, schema.UnprocessableContentError("the selection field type must be array", map[string]any{
         "cause": err.Error(),
       })
     }`)
@@ -172,7 +172,7 @@ func genConnectorFunctions(rawSchema *RawConnectorSchema) string {
 			sb.WriteString(`
     selection, err := queryFields.AsObject()
     if err != nil {
-      return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
         "cause": err.Error(),
       })
     }`)
@@ -182,14 +182,14 @@ func genConnectorFunctions(rawSchema *RawConnectorSchema) string {
 			argumentStr := fmt.Sprintf(`
     rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
     if err != nil {
-      return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
+      return nil, schema.UnprocessableContentError("failed to resolve argument variables", map[string]any{
         "cause": err.Error(),
       })
     }
     
     var args %s.%s
     if err = args.FromValue(rawArgs); err != nil {
-      return nil, schema.BadRequestError("failed to resolve arguments", map[string]any{
+      return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
         "cause": err.Error(),
       })
     }`, fn.PackageName, fn.ArgumentsType)
@@ -226,7 +226,7 @@ func genGeneralOperationResult(sb *strings.Builder, resultType *TypeInfo) {
 	} else {
 		sb.WriteString(`
     if rawResult == nil {
-      return nil, schema.BadRequestError("expected not null result", nil)
+      return nil, schema.UnprocessableContentError("expected not null result", nil)
     }
 `)
 	}
@@ -244,13 +244,13 @@ func genConnectorProcedures(rawSchema *RawConnectorSchema) string {
 		if fn.ResultType.IsScalar {
 			sb.WriteString(`
     if len(operation.Fields) > 0 {
-      return nil, schema.BadRequestError("cannot evaluate selection fields for scalar", nil)
+      return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
     }`)
 		} else if fn.ResultType.IsArray {
 			sb.WriteString(`
     selection, err := operation.Fields.AsArray()
     if err != nil {
-      return nil, schema.BadRequestError("the selection field type must be array", map[string]any{
+      return nil, schema.UnprocessableContentError("the selection field type must be array", map[string]any{
         "cause": err.Error(),
       })
     }`)
@@ -258,7 +258,7 @@ func genConnectorProcedures(rawSchema *RawConnectorSchema) string {
 			sb.WriteString(`
     selection, err := operation.Fields.AsObject()
     if err != nil {
-      return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
         "cause": err.Error(),
       })
     }`)
@@ -267,7 +267,7 @@ func genConnectorProcedures(rawSchema *RawConnectorSchema) string {
 			argumentStr := fmt.Sprintf(`
     var args %s.%s
     if err := json.Unmarshal(operation.Arguments, &args); err != nil {
-      return nil, schema.BadRequestError("failed to decode arguments", map[string]any{
+      return nil, schema.UnprocessableContentError("failed to decode arguments", map[string]any{
         "cause": err.Error(),
       })
     }`, fn.PackageName, fn.ArgumentsType)

--- a/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/templates/connector/connector.go.tmpl
@@ -34,7 +34,7 @@ func (c *Connector) GetSchema(ctx context.Context, configuration *types.Configur
 func (c *Connector) Query(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.QueryRequest) (schema.QueryResponse, error) {
   valueField, err := utils.EvalFunctionSelectionFieldValue(request)
   if err != nil {
- 		return nil, schema.BadRequestError(err.Error(), nil)
+ 		return nil, schema.UnprocessableContentError(err.Error(), nil)
   }
   requestVars := request.Variables
   if len(requestVars) == 0 {
@@ -73,7 +73,7 @@ func (c *Connector) Mutation(ctx context.Context, configuration *types.Configura
       }
       operationResults[i] = result
     default:
-      return nil, schema.BadRequestError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
+      return nil, schema.UnprocessableContentError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
     }
   }
 
@@ -87,7 +87,7 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
   switch request.Collection {
 {{.Queries}}
   default:
-    return nil, schema.BadRequestError(fmt.Sprintf("unsupported query: %s", request.Collection), nil)
+    return nil, schema.UnprocessableContentError(fmt.Sprintf("unsupported query: %s", request.Collection), nil)
   }
 }
 
@@ -97,7 +97,7 @@ func execProcedure(ctx context.Context, state *types.State, operation *schema.Mu
   switch operation.Name {
 {{.Procedures}}
   default:
-    return nil, schema.BadRequestError(fmt.Sprintf("unsupported procedure operation: %s", operation.Name), nil)
+    return nil, schema.UnprocessableContentError(fmt.Sprintf("unsupported procedure operation: %s", operation.Name), nil)
   }
 
   return schema.NewProcedureResult(result).Encode(), nil

--- a/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/connector.go.tmpl
@@ -29,7 +29,7 @@ func (c *Connector) GetSchema(ctx context.Context, configuration *types.Configur
 func (c *Connector) Query(ctx context.Context, configuration *types.Configuration, state *types.State, request *schema.QueryRequest) (schema.QueryResponse, error) {
   valueField, err := utils.EvalFunctionSelectionFieldValue(request)
 	if err != nil {
-		return nil, schema.BadRequestError(err.Error(), nil)
+		return nil, schema.UnprocessableContentError(err.Error(), nil)
 	}
   requestVars := request.Variables
   if len(requestVars) == 0 {
@@ -65,7 +65,7 @@ func (c *Connector) Mutation(ctx context.Context, configuration *types.Configura
 			}
 			operationResults[i] = result
 		default:
-			return nil, schema.BadRequestError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
+			return nil, schema.UnprocessableContentError(fmt.Sprintf("invalid operation type: %s", operation.Type), nil)
 		}
 	}
   return &schema.MutationResponse{
@@ -77,26 +77,26 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 	switch request.Collection {
 	case "getBool":
 		if len(queryFields) > 0 {
-			return nil, schema.BadRequestError("cannot evaluate selection fields for scalar", nil)
+			return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
 		}
 		return functions.FunctionGetBool(ctx, state)
 	case "getTypes":
 		selection, err := queryFields.AsObject()
 		if err != nil {
-			return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+			return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
 				"cause": err.Error(),
 			})
 		}
 		rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
 		if err != nil {
-			return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
+			return nil, schema.UnprocessableContentError("failed to resolve argument variables", map[string]any{
 				"cause": err.Error(),
 			})
 		}
 
 		var args functions.GetTypesArguments
 		if err = args.FromValue(rawArgs); err != nil {
-			return nil, schema.BadRequestError("failed to resolve arguments", map[string]any{
+			return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
 				"cause": err.Error(),
 			})
 		}
@@ -117,7 +117,7 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 	case "hello":
 		selection, err := queryFields.AsObject()
 		if err != nil {
-			return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+			return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
 				"cause": err.Error(),
 			})
 		}
@@ -138,20 +138,20 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 	case "getArticles":
 		selection, err := queryFields.AsArray()
 		if err != nil {
-			return nil, schema.BadRequestError("the selection field type must be array", map[string]any{
+			return nil, schema.UnprocessableContentError("the selection field type must be array", map[string]any{
 				"cause": err.Error(),
 			})
 		}
 		rawArgs, err := utils.ResolveArgumentVariables(request.Arguments, variables)
 		if err != nil {
-			return nil, schema.BadRequestError("failed to resolve argument variables", map[string]any{
+			return nil, schema.UnprocessableContentError("failed to resolve argument variables", map[string]any{
 				"cause": err.Error(),
 			})
 		}
 
 		var args functions.GetArticlesArguments
 		if err = args.FromValue(rawArgs); err != nil {
-			return nil, schema.BadRequestError("failed to resolve arguments", map[string]any{
+			return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
 				"cause": err.Error(),
 			})
 		}
@@ -161,7 +161,7 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 		}
 
 		if rawResult == nil {
-			return nil, schema.BadRequestError("expected not null result", nil)
+			return nil, schema.UnprocessableContentError("expected not null result", nil)
 		}
 
 		result, err := utils.EvalNestedColumnArrayIntoSlice(selection, rawResult)
@@ -171,7 +171,7 @@ func execQuery(ctx context.Context, state *types.State, request *schema.QueryReq
 		return result, nil
 
 	default:
-		return nil, schema.BadRequestError(fmt.Sprintf("unsupported query: %s", request.Collection), nil)
+		return nil, schema.UnprocessableContentError(fmt.Sprintf("unsupported query: %s", request.Collection), nil)
 	}
 }
 func execProcedure(ctx context.Context, state *types.State, operation *schema.MutationOperation) (schema.MutationOperationResults, error) {
@@ -180,13 +180,13 @@ func execProcedure(ctx context.Context, state *types.State, operation *schema.Mu
   case "create_article":
     selection, err := operation.Fields.AsObject()
     if err != nil {
-      return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
         "cause": err.Error(),
       })
     }
     var args functions.CreateArticleArguments
     if err := json.Unmarshal(operation.Arguments, &args); err != nil {
-      return nil, schema.BadRequestError("failed to decode arguments", map[string]any{
+      return nil, schema.UnprocessableContentError("failed to decode arguments", map[string]any{
         "cause": err.Error(),
       })
     }
@@ -203,7 +203,7 @@ func execProcedure(ctx context.Context, state *types.State, operation *schema.Mu
     }
 	case "increase":
 		if len(operation.Fields) > 0 {
-			return nil, schema.BadRequestError("cannot evaluate selection fields for scalar", nil)
+			return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
     }
     var err error
     result, err = functions.Increase(ctx, state)
@@ -213,13 +213,13 @@ func execProcedure(ctx context.Context, state *types.State, operation *schema.Mu
   case "createAuthor":
     selection, err := operation.Fields.AsObject()
     if err != nil {
-      return nil, schema.BadRequestError("the selection field type must be object", map[string]any{
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
         "cause": err.Error(),
       })
     }
     var args functions.CreateAuthorArguments
     if err := json.Unmarshal(operation.Arguments, &args); err != nil {
-      return nil, schema.BadRequestError("failed to decode arguments", map[string]any{
+      return nil, schema.UnprocessableContentError("failed to decode arguments", map[string]any{
         "cause": err.Error(),
       })
     }
@@ -237,13 +237,13 @@ func execProcedure(ctx context.Context, state *types.State, operation *schema.Mu
 	case "createAuthors":
 		selection, err := operation.Fields.AsArray()
 		if err != nil {
-			return nil, schema.BadRequestError("the selection field type must be array", map[string]any{
+			return nil, schema.UnprocessableContentError("the selection field type must be array", map[string]any{
 				"cause": err.Error(),
 			})
 		}
 		var args functions.CreateAuthorsArguments
 		if err := json.Unmarshal(operation.Arguments, &args); err != nil {
-			return nil, schema.BadRequestError("failed to decode arguments", map[string]any{
+			return nil, schema.UnprocessableContentError("failed to decode arguments", map[string]any{
 				"cause": err.Error(),
 			})
 		}
@@ -252,14 +252,14 @@ func execProcedure(ctx context.Context, state *types.State, operation *schema.Mu
 			return nil, err
 		}
 		if rawResult == nil {
-			return nil, schema.BadRequestError("expected not null result", nil)
+			return nil, schema.UnprocessableContentError("expected not null result", nil)
 		}
 		result, err = utils.EvalNestedColumnArrayIntoSlice(selection, rawResult)
 		if err != nil {
       return nil, err
     }
   default:
-    return nil, schema.BadRequestError(fmt.Sprintf("unsupported procedure operation: %s", operation.Name), nil)
+    return nil, schema.UnprocessableContentError(fmt.Sprintf("unsupported procedure operation: %s", operation.Name), nil)
   }
   return schema.NewProcedureResult(result).Encode(), nil
 }

--- a/connector/cli.go
+++ b/connector/cli.go
@@ -11,14 +11,11 @@ import (
 
 // ServeCommandArguments contains argument flags of the serve command
 type ServeCommandArguments struct {
-	Configuration       string `help:"Configuration directory." env:"HASURA_CONFIGURATION_DIRECTORY"`
-	Port                uint   `help:"Serve Port." env:"HASURA_CONNECTOR_PORT" default:"8080"`
-	ServiceTokenSecret  string `help:"Service token secret." env:"HASURA_SERVICE_TOKEN_SECRET"`
-	OtlpEndpoint        string `help:"OpenTelemetry receiver endpoint that is set as default for all types." env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	OtlpTracesEndpoint  string `help:"OpenTelemetry endpoint for traces." env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
-	OtlpInsecure        bool   `help:"Disable LTS for OpenTelemetry gRPC exporters." env:"OTEL_EXPORTER_OTLP_INSECURE"`
-	OtlpMetricsEndpoint string `help:"OpenTelemetry endpoint for metrics." env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
-	ServiceName         string `help:"OpenTelemetry service name." env:"OTEL_SERVICE_NAME"`
+	OTLPConfig
+
+	Configuration      string `help:"Configuration directory." env:"HASURA_CONFIGURATION_DIRECTORY"`
+	Port               uint   `help:"Serve Port." env:"HASURA_CONNECTOR_PORT" default:"8080"`
+	ServiceTokenSecret string `help:"Service token secret." env:"HASURA_SERVICE_TOKEN_SECRET"`
 }
 
 // ServeCLI is used for CLI argument binding
@@ -67,13 +64,10 @@ func StartCustom[Configuration any, State any](cli ConnectorCLI, connector Conne
 	switch command {
 	case "serve":
 		server, err := NewServer[Configuration, State](connector, &ServerOptions{
-			Configuration:       serveCLI.Serve.Configuration,
-			ServiceTokenSecret:  serveCLI.Serve.ServiceTokenSecret,
-			OTLPEndpoint:        serveCLI.Serve.OtlpEndpoint,
-			OTLPInsecure:        serveCLI.Serve.OtlpInsecure,
-			OTLPTracesEndpoint:  serveCLI.Serve.OtlpTracesEndpoint,
-			OTLPMetricsEndpoint: serveCLI.Serve.OtlpMetricsEndpoint,
-			ServiceName:         serveCLI.Serve.ServiceName,
+			Configuration:      serveCLI.Serve.Configuration,
+			ServiceTokenSecret: serveCLI.Serve.ServiceTokenSecret,
+			ServiceName:        serveCLI.Serve.ServiceName,
+			OTLPConfig:         serveCLI.Serve.OTLPConfig,
 		}, append(options, WithLogger(*logger))...)
 		if err != nil {
 			return err

--- a/connector/http.go
+++ b/connector/http.go
@@ -90,7 +90,7 @@ func (rt *router) Build() *http.ServeMux {
 							Interface("error", err).
 							Msg("failed to read request")
 
-						writeJson(w, rt.logger, http.StatusBadRequest, schema.ErrorResponse{
+						writeJson(w, rt.logger, http.StatusUnprocessableEntity, schema.ErrorResponse{
 							Message: "failed to read request",
 							Details: map[string]any{
 								"cause": err,
@@ -146,7 +146,7 @@ func (rt *router) Build() *http.ServeMux {
 					err := schema.ErrorResponse{
 						Message: fmt.Sprintf("Invalid content type %s, accept %s only", contentType, contentTypeJson),
 					}
-					writeJson(w, rt.logger, http.StatusBadRequest, err)
+					writeJson(w, rt.logger, http.StatusUnprocessableEntity, err)
 
 					rt.logger.Error().
 						Str("request_id", requestID).

--- a/connector/server.go
+++ b/connector/server.go
@@ -23,14 +23,12 @@ import (
 
 // ServerOptions presents the configuration object of the connector http server
 type ServerOptions struct {
-	Configuration       string
-	InlineConfig        bool
-	ServiceTokenSecret  string
-	OTLPEndpoint        string
-	OTLPInsecure        bool
-	OTLPTracesEndpoint  string
-	OTLPMetricsEndpoint string
-	ServiceName         string
+	OTLPConfig
+
+	Configuration      string
+	InlineConfig       bool
+	ServiceTokenSecret string
+	ServiceName        string
 }
 
 // Server implements the [NDC API specification] for the connector
@@ -55,10 +53,7 @@ func NewServer[Configuration any, State any](connector Connector[Configuration, 
 		opts(defaultOptions)
 	}
 	defaultOptions.logger.Debug().
-		Str("endpoint", options.OTLPEndpoint).
-		Str("traces_endpoint", options.OTLPTracesEndpoint).
-		Str("metrics_endpoint", options.OTLPMetricsEndpoint).
-		Str("service_name", options.ServiceName).
+		Any("otlp", options.OTLPConfig).
 		Str("version", defaultOptions.version).
 		Str("metrics_prefix", defaultOptions.metricsPrefix).
 		Msg("initialize OpenTelemetry")
@@ -80,7 +75,7 @@ func NewServer[Configuration any, State any](connector Connector[Configuration, 
 		options.ServiceName = defaultOptions.serviceName
 	}
 
-	telemetry, err := setupOTelSDK(ctx, options, defaultOptions.version, defaultOptions.metricsPrefix, defaultOptions.logger)
+	telemetry, err := setupOTelSDK(ctx, &options.OTLPConfig, defaultOptions.version, defaultOptions.metricsPrefix, defaultOptions.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +382,9 @@ func (s *Server[Configuration, State]) buildHandler() *http.ServeMux {
 	router.Use("/mutation/explain", http.MethodPost, s.withAuth(s.MutationExplain))
 	router.Use("/mutation", http.MethodPost, s.withAuth(s.Mutation))
 	router.Use("/health", http.MethodGet, s.Health)
-	router.Use("/metrics", http.MethodGet, s.withAuth(promhttp.Handler().ServeHTTP))
+	if s.options.MetricsExporter == string(otelMetricsExporterPrometheus) {
+		router.Use("/metrics", http.MethodGet, s.withAuth(promhttp.Handler().ServeHTTP))
+	}
 
 	return router.Build()
 }

--- a/connector/server_test.go
+++ b/connector/server_test.go
@@ -357,7 +357,7 @@ func TestServerConnector(t *testing.T) {
 			t.Errorf("expected no error, got %s", err)
 			t.FailNow()
 		}
-		assertHTTPResponse(t, res, http.StatusBadRequest, schema.ErrorResponse{
+		assertHTTPResponse(t, res, http.StatusUnprocessableEntity, schema.ErrorResponse{
 			Message: "failed to decode json request body",
 			Details: map[string]any{
 				"cause": "json: cannot unmarshal string into Go value of type map[string]interface {}",
@@ -410,7 +410,7 @@ func TestServerConnector(t *testing.T) {
 			t.Errorf("expected no error, got %s", err)
 			t.FailNow()
 		}
-		assertHTTPResponse(t, res, http.StatusBadRequest, schema.ErrorResponse{
+		assertHTTPResponse(t, res, http.StatusUnprocessableEntity, schema.ErrorResponse{
 			Message: "failed to decode json request body",
 			Details: map[string]any{
 				"cause": "json: cannot unmarshal string into Go value of type map[string]interface {}",
@@ -461,7 +461,7 @@ func TestServerConnector(t *testing.T) {
 			t.Errorf("expected no error, got %s", err)
 			t.FailNow()
 		}
-		assertHTTPResponse(t, res, http.StatusBadRequest, schema.ErrorResponse{
+		assertHTTPResponse(t, res, http.StatusUnprocessableEntity, schema.ErrorResponse{
 			Message: "failed to decode json request body",
 			Details: map[string]any{
 				"cause": "field arguments in QueryRequest: required",
@@ -489,7 +489,7 @@ func TestServerConnector(t *testing.T) {
 			t.Errorf("expected no error, got %s", err)
 			t.FailNow()
 		}
-		assertHTTPResponse(t, res, http.StatusBadRequest, schema.ErrorResponse{
+		assertHTTPResponse(t, res, http.StatusUnprocessableEntity, schema.ErrorResponse{
 			Message: "failed to decode json request body",
 			Details: map[string]any{
 				"cause": "field collection_relationships in MutationRequest: required",

--- a/connector/telemetry.go
+++ b/connector/telemetry.go
@@ -72,8 +72,8 @@ type OTLPConfig struct {
 	OtlpTracesProtocol     string `help:"OpenTelemetry receiver protocol for traces." env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"`
 	OtlpMetricsProtocol    string `help:"OpenTelemetry receiver protocol for metrics." env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
 	OtlpCompression        string `help:"Enable compression for OTLP exporters. Accept: none, gzip" env:"OTEL_EXPORTER_OTLP_COMPRESSION" default:"gzip"`
-	OtlpTraceCompression   string `help:"Enable compression for OTLP traces exporter. Accept: none, gzip" env:"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION" default:"gzip"`
-	OtlpMetricsCompression string `help:"Enable compression for OTLP metrics exporter. Accept: none, gzip." env:"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION" default:"gzip"`
+	OtlpTraceCompression   string `help:"Enable compression for OTLP traces exporter. Accept: none, gzip" env:"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION"`
+	OtlpMetricsCompression string `help:"Enable compression for OTLP metrics exporter. Accept: none, gzip." env:"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION"`
 
 	MetricsExporter string `help:"Metrics export type. Accept: none, otlp, prometheus." env:"OTEL_METRICS_EXPORTER" default:"none"`
 	PrometheusPort  *uint  `help:"Prometheus port for the Prometheus HTTP server. Use /metrics endpoint of the connector server if empty" env:"OTEL_EXPORTER_PROMETHEUS_PORT"`
@@ -167,6 +167,7 @@ func setupOTelSDK(ctx context.Context, config *OTLPConfig, serviceVersion, metri
 	}
 	otel.SetTracerProvider(traceProvider)
 
+	// configure metrics exporter
 	metricsExporterType, err := parseOTELMetricsExporterType(config.MetricsExporter)
 	if err != nil {
 		return nil, err
@@ -198,12 +199,12 @@ func setupOTelSDK(ctx context.Context, config *OTLPConfig, serviceVersion, metri
 			utils.GetDefaultPtr(config.OtlpMetricsInsecure, config.OtlpInsecure),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse OTLP traces endpoint: %s", err)
+			return nil, fmt.Errorf("failed to parse OTLP metrics endpoint: %s", err)
 		}
 
 		compressorStr, compressorInt, err := parseOTLPCompression(utils.GetDefault(config.OtlpMetricsCompression, config.OtlpCompression))
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse OTLP traces compression: %s", err)
+			return nil, fmt.Errorf("failed to parse OTLP metrics compression: %s", err)
 		}
 
 		if protocol == otlpProtocolGRPC {

--- a/connector/telemetry.go
+++ b/connector/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-logr/zerologr"
+	"github.com/hasura/ndc-sdk-go/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/rs/zerolog"
@@ -29,11 +30,54 @@ import (
 	traceapi "go.opentelemetry.io/otel/trace"
 )
 
+const (
+	otlpDefaultGRPCPort = 4317
+	otlpDefaultHTTPPort = 4318
+	otlpCompressionNone = "none"
+	otlpCompressionGzip = "gzip"
+)
+
+type otlpProtocol string
+
+const (
+	otlpProtocolGRPC         otlpProtocol = "grpc"
+	otlpProtocolHTTPProtobuf otlpProtocol = "http/protobuf"
+)
+
+// defines the type of OpenTelemetry metrics exporter
+type otelMetricsExporterType string
+
+const (
+	otelMetricsExporterNone       otelMetricsExporterType = "none"
+	otelMetricsExporterOTLP       otelMetricsExporterType = "otlp"
+	otelMetricsExporterPrometheus otelMetricsExporterType = "prometheus"
+)
+
 var (
 	userVisibilityAttribute = traceapi.WithAttributes(attribute.String("internal.visibility", "user"))
 	successStatusAttribute  = attribute.String("status", "success")
 	failureStatusAttribute  = attribute.String("status", "failure")
 )
+
+// OTLPConfig contains configuration for OpenTelemetry exporter
+type OTLPConfig struct {
+	ServiceName            string `help:"OpenTelemetry service name." env:"OTEL_SERVICE_NAME"`
+	OtlpEndpoint           string `help:"OpenTelemetry receiver endpoint that is set as default for all types." env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	OtlpTracesEndpoint     string `help:"OpenTelemetry endpoint for traces." env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
+	OtlpMetricsEndpoint    string `help:"OpenTelemetry endpoint for metrics." env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
+	OtlpInsecure           *bool  `help:"Disable LTS for OpenTelemetry exporters." env:"OTEL_EXPORTER_OTLP_INSECURE"`
+	OtlpTracesInsecure     *bool  `help:"Disable LTS for OpenTelemetry traces exporter." env:"OTEL_EXPORTER_OTLP_TRACES_INSECURE"`
+	OtlpMetricsInsecure    *bool  `help:"Disable LTS for OpenTelemetry metrics exporter." env:"OTEL_EXPORTER_OTLP_METRICS_INSECURE"`
+	OtlpProtocol           string `help:"OpenTelemetry receiver protocol for all types." env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
+	OtlpTracesProtocol     string `help:"OpenTelemetry receiver protocol for traces." env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"`
+	OtlpMetricsProtocol    string `help:"OpenTelemetry receiver protocol for metrics." env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
+	OtlpCompression        string `help:"Enable compression for OTLP exporters. Accept: none, gzip" env:"OTEL_EXPORTER_OTLP_COMPRESSION" default:"gzip"`
+	OtlpTraceCompression   string `help:"Enable compression for OTLP traces exporter. Accept: none, gzip" env:"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION" default:"gzip"`
+	OtlpMetricsCompression string `help:"Enable compression for OTLP metrics exporter. Accept: none, gzip." env:"OTEL_EXPORTER_OTLP_METRICS_COMPRESSION" default:"gzip"`
+
+	MetricsExporter string `help:"Metrics export type. Accept: none, otlp, prometheus." env:"OTEL_METRICS_EXPORTER" default:"none"`
+	PrometheusPort  *uint  `help:"Prometheus port for the Prometheus HTTP server. Use /metrics endpoint of the connector server if empty" env:"OTEL_EXPORTER_PROMETHEUS_PORT"`
+}
 
 type TelemetryState struct {
 	Tracer                          *Tracer
@@ -51,40 +95,47 @@ type TelemetryState struct {
 
 // setupOTelSDK bootstraps the OpenTelemetry pipeline.
 // If it does not return an error, make sure to call shutdown for proper cleanup.
-func setupOTelSDK(ctx context.Context, serverOptions *ServerOptions, serviceVersion, metricsPrefix string, logger zerolog.Logger) (*TelemetryState, error) {
+func setupOTelSDK(ctx context.Context, config *OTLPConfig, serviceVersion, metricsPrefix string, logger zerolog.Logger) (*TelemetryState, error) {
 
 	otel.SetLogger(zerologr.New(&logger))
-	tracesEndpoint := serverOptions.OTLPTracesEndpoint
-	if tracesEndpoint == "" {
-		tracesEndpoint = serverOptions.OTLPEndpoint
-	}
-	metricsEndpoint := serverOptions.OTLPMetricsEndpoint
-	if metricsEndpoint == "" {
-		metricsEndpoint = serverOptions.OTLPEndpoint
-	}
+	tracesEndpoint := utils.GetDefault(config.OtlpTracesEndpoint, config.OtlpEndpoint)
+	metricsEndpoint := utils.GetDefault(config.OtlpMetricsEndpoint, config.OtlpEndpoint)
 
 	// Set up resource.
-	res, err := newResource(serverOptions.ServiceName, serviceVersion)
+	res, err := newResource(config.ServiceName, serviceVersion)
 	if err != nil {
 		return nil, err
 	}
 
 	var traceProvider *trace.TracerProvider
 	if tracesEndpoint != "" {
+		endpoint, protocol, insecure, err := parseOTLPEndpoint(
+			tracesEndpoint,
+			utils.GetDefault(config.OtlpTracesProtocol, config.OtlpProtocol),
+			utils.GetDefaultPtr(config.OtlpTracesInsecure, config.OtlpInsecure),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse OTLP traces endpoint: %s", err)
+		}
+
+		compressorStr, compressorInt, err := parseOTLPCompression(utils.GetDefault(config.OtlpTraceCompression, config.OtlpCompression))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse OTLP traces compression: %s", err)
+		}
+
 		// Set up propagator.
 		prop := newPropagator()
 		otel.SetTextMapPropagator(prop)
 
 		var traceExporter *otlptrace.Exporter
 
-		// use grpc protocol by default if the scheme is empty
-		if !strings.HasPrefix(tracesEndpoint, "http://") && !strings.HasPrefix(tracesEndpoint, "https://") {
+		if protocol == otlpProtocolGRPC {
 			options := []otlptracegrpc.Option{
-				otlptracegrpc.WithEndpoint(tracesEndpoint),
-				otlptracegrpc.WithCompressor("gzip"),
+				otlptracegrpc.WithEndpoint(endpoint),
+				otlptracegrpc.WithCompressor(compressorStr),
 			}
 
-			if serverOptions.OTLPInsecure {
+			if insecure {
 				options = append(options, otlptracegrpc.WithInsecure())
 			}
 
@@ -93,17 +144,11 @@ func setupOTelSDK(ctx context.Context, serverOptions *ServerOptions, serviceVers
 				return nil, err
 			}
 		} else {
-			// Set up trace exporter.
-			endpointURL, err := url.Parse(tracesEndpoint)
-			if err != nil {
-				return nil, err
-			}
-
 			options := []otlptracehttp.Option{
-				otlptracehttp.WithEndpoint(endpointURL.Host),
-				otlptracehttp.WithCompression(otlptracehttp.GzipCompression),
+				otlptracehttp.WithEndpoint(endpoint),
+				otlptracehttp.WithCompression(otlptracehttp.Compression(compressorInt)),
 			}
-			if endpointURL.Scheme == "http" {
+			if insecure {
 				options = append(options, otlptracehttp.WithInsecure())
 			}
 
@@ -122,32 +167,52 @@ func setupOTelSDK(ctx context.Context, serverOptions *ServerOptions, serviceVers
 	}
 	otel.SetTracerProvider(traceProvider)
 
-	// disable default process and go collector metrics
-	prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	prometheus.Unregister(collectors.NewGoCollector())
-
-	// The exporter embeds a default OpenTelemetry Reader and
-	// implements prometheus.Collector, allowing it to be used as
-	// both a Reader and Collector.
-	prometheusExporter, err := otelPrometheus.New()
+	metricsExporterType, err := parseOTELMetricsExporterType(config.MetricsExporter)
 	if err != nil {
 		return nil, err
 	}
 
-	metricOptions := []metric.Option{
-		metric.WithResource(res),
-		metric.WithReader(prometheusExporter),
-	}
+	metricOptions := []metric.Option{metric.WithResource(res)}
 
-	if metricsEndpoint != "" {
-		// use grpc protocol by default if the scheme is empty
-		if !strings.HasPrefix(metricsEndpoint, "http://") && !strings.HasPrefix(metricsEndpoint, "https://") {
+	// disable default process and go collector metrics
+	prometheus.Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	prometheus.Unregister(collectors.NewGoCollector())
+
+	switch metricsExporterType {
+	case otelMetricsExporterPrometheus:
+		// The exporter embeds a default OpenTelemetry Reader and
+		// implements prometheus.Collector, allowing it to be used as
+		// both a Reader and Collector.
+		prometheusExporter, err := otelPrometheus.New()
+		if err != nil {
+			return nil, err
+		}
+		metricOptions = append(metricOptions, metric.WithReader(prometheusExporter))
+	case otelMetricsExporterOTLP:
+		if metricsEndpoint == "" {
+			return nil, errors.New("OTLP endpoint is required for metrics exporter")
+		}
+		endpoint, protocol, insecure, err := parseOTLPEndpoint(
+			metricsEndpoint,
+			utils.GetDefault(config.OtlpMetricsProtocol, config.OtlpProtocol),
+			utils.GetDefaultPtr(config.OtlpMetricsInsecure, config.OtlpInsecure),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse OTLP traces endpoint: %s", err)
+		}
+
+		compressorStr, compressorInt, err := parseOTLPCompression(utils.GetDefault(config.OtlpMetricsCompression, config.OtlpCompression))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse OTLP traces compression: %s", err)
+		}
+
+		if protocol == otlpProtocolGRPC {
 			options := []otlpmetricgrpc.Option{
-				otlpmetricgrpc.WithEndpoint(metricsEndpoint),
-				otlpmetricgrpc.WithCompressor("gzip"),
+				otlpmetricgrpc.WithEndpoint(endpoint),
+				otlpmetricgrpc.WithCompressor(compressorStr),
 			}
 
-			if serverOptions.OTLPInsecure {
+			if insecure {
 				options = append(options, otlpmetricgrpc.WithInsecure())
 			}
 
@@ -157,16 +222,11 @@ func setupOTelSDK(ctx context.Context, serverOptions *ServerOptions, serviceVers
 			}
 			metricOptions = append(metricOptions, metric.WithReader(metric.NewPeriodicReader(metricExporter)))
 		} else {
-
-			endpointURL, err := url.Parse(metricsEndpoint)
-			if err != nil {
-				return nil, err
-			}
 			options := []otlpmetrichttp.Option{
-				otlpmetrichttp.WithEndpoint(endpointURL.Host),
-				otlpmetrichttp.WithCompression(otlpmetrichttp.GzipCompression),
+				otlpmetrichttp.WithEndpoint(endpoint),
+				otlpmetrichttp.WithCompression(otlpmetrichttp.Compression(compressorInt)),
 			}
-			if endpointURL.Scheme == "http" {
+			if insecure {
 				options = append(options, otlpmetrichttp.WithInsecure())
 			}
 
@@ -198,8 +258,8 @@ func setupOTelSDK(ctx context.Context, serverOptions *ServerOptions, serviceVers
 	}
 
 	state := &TelemetryState{
-		Tracer:   &Tracer{traceProvider.Tracer(serverOptions.ServiceName)},
-		Meter:    meterProvider.Meter(serverOptions.ServiceName),
+		Tracer:   &Tracer{traceProvider.Tracer(config.ServiceName)},
+		Meter:    meterProvider.Meter(config.ServiceName),
 		Shutdown: shutdownFunc,
 	}
 
@@ -315,4 +375,60 @@ func (t *Tracer) StartInternal(ctx context.Context, spanName string, opts ...tra
 
 func httpStatusAttribute(code int) attribute.KeyValue {
 	return attribute.Int("http_status", code)
+}
+
+func parseOTLPEndpoint(endpoint string, protocol string, insecurePtr *bool) (string, otlpProtocol, bool, error) {
+	uri, err := url.Parse(endpoint)
+	if err != nil {
+		return "", otlpProtocol(""), false, err
+	}
+
+	insecure := utils.GetDefaultValuePtr(insecurePtr, uri.Scheme == "http")
+	host := uri.Host
+	if uri.Port() == "" {
+		port := 443
+		if insecure {
+			port = 80
+		}
+		host = fmt.Sprintf("%s:%d", uri.Hostname(), port)
+	}
+
+	switch protocol {
+	case string(otlpProtocolGRPC):
+		return host, otlpProtocolGRPC, insecure, nil
+	case string(otlpProtocolHTTPProtobuf):
+		return host, otlpProtocol(protocol), insecure, nil
+	case "":
+		// auto detect via default OTLP port
+		if uri.Port() == fmt.Sprint(otlpDefaultHTTPPort) {
+			return host, otlpProtocol(protocol), insecure, nil
+		}
+		return host, otlpProtocolGRPC, insecure, nil
+	default:
+		return "", otlpProtocol(""), false, fmt.Errorf("invalid OTLP protocol %s", protocol)
+	}
+}
+
+func parseOTLPCompression(input string) (string, int, error) {
+	switch input {
+	case otlpCompressionGzip, "":
+		return otlpCompressionGzip, int(otlptracehttp.GzipCompression), nil
+	case otlpCompressionNone:
+		return otlpCompressionNone, int(otlptracehttp.NoCompression), nil
+	default:
+		return "", 0, fmt.Errorf("invalid OTLP compression type, accept none, gzip only")
+	}
+}
+
+func parseOTELMetricsExporterType(input string) (otelMetricsExporterType, error) {
+	switch input {
+	case string(otelMetricsExporterNone), "":
+		return otelMetricsExporterNone, nil
+	case string(otelMetricsExporterOTLP):
+		return otelMetricsExporterOTLP, nil
+	case string(otelMetricsExporterPrometheus):
+		return otelMetricsExporterPrometheus, nil
+	default:
+		return otelMetricsExporterNone, fmt.Errorf("invalid metrics exporter type: %s", input)
+	}
 }

--- a/example/codegen/connector_test.go
+++ b/example/codegen/connector_test.go
@@ -613,7 +613,7 @@ func TestQueries(t *testing.T) {
 		},
 		{
 			name:   "hello_failure_array",
-			status: http.StatusBadRequest,
+			status: http.StatusUnprocessableEntity,
 			body: `{
 				"collection": "hello",
 				"query": {
@@ -660,7 +660,7 @@ func TestQueries(t *testing.T) {
 		},
 		{
 			name:   "getArticles_failure_object",
-			status: http.StatusBadRequest,
+			status: http.StatusUnprocessableEntity,
 			body: `{
 				"collection": "getArticles",
 				"query": {
@@ -786,7 +786,7 @@ func TestProcedures(t *testing.T) {
 		},
 		{
 			name:   "create_article_array_400",
-			status: http.StatusBadRequest,
+			status: http.StatusUnprocessableEntity,
 			body: `{
 				"operations": [
 					{
@@ -841,8 +841,8 @@ func TestProcedures(t *testing.T) {
 			}]`,
 		},
 		{
-			name:   "createAuthors_object_400",
-			status: http.StatusBadRequest,
+			name:   "createAuthors_object_422",
+			status: http.StatusUnprocessableEntity,
 			body: `{
 				"operations": [
 					{
@@ -881,8 +881,8 @@ func TestProcedures(t *testing.T) {
 			response: `1`,
 		},
 		{
-			name:   "increase_400",
-			status: http.StatusBadRequest,
+			name:   "increase_422",
+			status: http.StatusUnprocessableEntity,
 			body: `{
 				"operations": [
 					{

--- a/utils/connector.go
+++ b/utils/connector.go
@@ -194,7 +194,7 @@ func EvalFunctionSelectionFieldValue(request *schema.QueryRequest) (schema.Neste
 	}
 	valueColumn, err := valueField.AsColumn()
 	if err != nil {
-		return nil, schema.BadRequestError(fmt.Sprintf("__value: %s", err), nil)
+		return nil, schema.UnprocessableContentError(fmt.Sprintf("__value: %s", err), nil)
 	}
 	if valueColumn.Column != "__value" {
 		return nil, errors.New(errFunctionValueFieldRequired)

--- a/utils/encode.go
+++ b/utils/encode.go
@@ -77,11 +77,11 @@ func encodeObject(input any) (map[string]any, error) {
 	case MapEncoder:
 		return value.ToMap(), nil
 	case Scalar:
-		return nil, schema.BadRequestError("cannot encode scalar to object", map[string]any{
+		return nil, schema.UnprocessableContentError("cannot encode scalar to object", map[string]any{
 			"value": input,
 		})
 	case bool, string, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, complex64, complex128, time.Time, time.Duration, time.Ticker, *bool, *string, *int, *int8, *int16, *int32, *int64, *uint, *uint8, *uint16, *uint32, *uint64, *float32, *float64, *complex64, *complex128, *time.Time, *time.Duration, *time.Ticker, []bool, []string, []int, []int8, []int16, []int32, []int64, []uint, []uint8, []uint16, []uint32, []uint64, []float32, []float64, []complex64, []complex128, []time.Time, []time.Duration, []time.Ticker:
-		return nil, schema.BadRequestError("failed to encode object", map[string]any{
+		return nil, schema.UnprocessableContentError("failed to encode object", map[string]any{
 			"value": input,
 		})
 	default:
@@ -93,7 +93,7 @@ func encodeObject(input any) (map[string]any, error) {
 		case reflect.Struct:
 			return encodeStruct(inputValue), nil
 		default:
-			return nil, schema.BadRequestError(fmt.Sprintf("failed to encode object, got %s", kind.String()), map[string]any{
+			return nil, schema.UnprocessableContentError(fmt.Sprintf("failed to encode object, got %s", kind.String()), map[string]any{
 				"value": input,
 			})
 		}
@@ -175,7 +175,7 @@ func EncodeObjects(input any) ([]map[string]any, error) {
 	}
 	inputValue := reflect.ValueOf(input)
 	if inputValue.Kind() != reflect.Array && inputValue.Kind() != reflect.Slice {
-		return nil, schema.BadRequestError("failed to encode array objects", map[string]any{
+		return nil, schema.UnprocessableContentError("failed to encode array objects", map[string]any{
 			"value": input,
 		})
 	}

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -1,0 +1,30 @@
+package utils
+
+// GetDefault returns the value or default one if value is empty
+func GetDefault[T comparable](value T, defaultValue T) T {
+	var empty T
+	if value == empty {
+		return defaultValue
+	}
+	return value
+}
+
+// GetDefaultPtr returns the first pointer or default one if GetDefaultPtr is nil
+func GetDefaultPtr[T any](value *T, defaultValue *T) *T {
+	if value == nil {
+		return defaultValue
+	}
+	return value
+}
+
+// GetDefaultValuePtr return the value of pointer or default one if the value of pointer is null or empty
+func GetDefaultValuePtr[T comparable](value *T, defaultValue T) T {
+	if value == nil {
+		return defaultValue
+	}
+	var empty T
+	if *value == empty {
+		return defaultValue
+	}
+	return *value
+}


### PR DESCRIPTION
- Improve OTEL configuration options. The SDK no longer detects HTTP protocol via `http(s)` scheme in the URL. By default, the OTEL exporter uses GRPC protocol. You can change to HTTP protocol by using port `4318` or set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
- Now you can choose only one metrics exporter by `OTEL_METRICS_EXPORTER=<none|otlp|prometheus>` variable. By default metrics exporter is disabled (`none`).
- If `OTEL_METRICS_EXPORTER != prometheus`, the `/metrics` route returns HTTP 404. You can change Prometheus service to another port with `OTEL_EXPORTER_PROMETHEUS_PORT` variable.
- Bad request HTTP status is changed to `HTTP 422`. Engine v3 only exposes errors with this status ([source](https://github.com/hasura/graphql-engine/blob/267d7fe7517ac001ca5a461ef757fbf625328fa0/v3/engine/src/execute/error.rs#L207)).  