### PR TITLE
Add biginteger representation

### DIFF
--- a/cmd/ndc-go-sdk/README.md
+++ b/cmd/ndc-go-sdk/README.md
@@ -190,7 +190,7 @@ The basic scalar types supported are:
 | Int8        | int8, uin8                  | A 8-bit signed integer with a minimum value of -2^7 and a maximum value of 2^7 - 1    | int8                |
 | Int16       | int16, uint16               | A 16-bit signed integer with a minimum value of -2^15 and a maximum value of 2^15 - 1 | int16               |
 | Int32       | int32, uint32               | A 32-bit signed integer with a minimum value of -2^31 and a maximum value of 2^31 - 1 | int32               |
-| Int64       | int64, uint64               | A 64-bit signed integer with a minimum value of -2^63 and a maximum value of 2^63 - 1 | int32               |
+| Int64       | int64, uint64               | A 64-bit signed integer with a minimum value of -2^63 and a maximum value of 2^63 - 1 | int64               |
 | Bigint      | scalar.BigInt               | A 64-bit signed integer with a minimum value of -2^63 and a maximum value of 2^63 - 1 | string              |
 | Float32     | float32                     | An IEEE-754 single-precision floating-point number                                    | float32             |
 | Float64     | float64                     | An IEEE-754 double-precision floating-point number                                    | float64             |
@@ -198,8 +198,6 @@ The basic scalar types supported are:
 | Date        | scalar.Date                 | ISO 8601 date                                                                         | string              |
 | TimestampTZ | time.Time                   | ISO 8601 timestamp-with-timezone                                                      | string              |
 | Enum        |                             | Enumeration values                                                                    | string              |
-
-> json.Unmarshaler can't automatically decode string to `int64` value. If you want to parse int64 from string, use `scalar.BigInt` instead
 
 Alias scalar types will be inferred to the origin type in the schema.
 

--- a/cmd/ndc-go-sdk/schema.go
+++ b/cmd/ndc-go-sdk/schema.go
@@ -30,6 +30,7 @@ const (
 	ScalarInt64       ScalarName = "Int64"
 	ScalarFloat32     ScalarName = "Float32"
 	ScalarFloat64     ScalarName = "Float64"
+	ScalarBigInt      ScalarName = "BigInt"
 	ScalarBigDecimal  ScalarName = "BigDecimal"
 	ScalarUUID        ScalarName = "UUID"
 	ScalarDate        ScalarName = "Date"
@@ -69,9 +70,7 @@ var defaultScalarTypes = map[ScalarName]schema.ScalarType{
 	ScalarInt64: {
 		AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
 		ComparisonOperators: map[string]schema.ComparisonOperatorDefinition{},
-		// json.Unmarshaler can't automatically parse integer to int64.
-		// if you want to parse int64 from string, use scalar.BigInt instead.
-		Representation: schema.NewTypeRepresentationInt32().Encode(),
+		Representation:      schema.NewTypeRepresentationInt64().Encode(),
 	},
 	ScalarFloat32: {
 		AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
@@ -82,6 +81,11 @@ var defaultScalarTypes = map[ScalarName]schema.ScalarType{
 		AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
 		ComparisonOperators: map[string]schema.ComparisonOperatorDefinition{},
 		Representation:      schema.NewTypeRepresentationFloat64().Encode(),
+	},
+	ScalarBigInt: {
+		AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
+		ComparisonOperators: map[string]schema.ComparisonOperatorDefinition{},
+		Representation:      schema.NewTypeRepresentationBigInteger().Encode(),
 	},
 	ScalarBigDecimal: {
 		AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
@@ -587,7 +591,7 @@ func (sp *SchemaParser) parseType(rawSchema *RawConnectorSchema, rootType *TypeI
 				case "Date":
 					scalarSchema.Representation = schema.NewTypeRepresentationDate().Encode()
 				case "BigInt":
-					scalarSchema.Representation = schema.NewTypeRepresentationInt64().Encode()
+					scalarSchema.Representation = schema.NewTypeRepresentationBigInteger().Encode()
 				}
 			}
 

--- a/cmd/ndc-go-sdk/testdata/basic/expected/functions.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/functions.go.tmpl
@@ -3,6 +3,7 @@ package functions
 import (
   "encoding/json"
   "errors"
+  "github.com/hasura/ndc-sdk-go/scalar"
   "github.com/hasura/ndc-sdk-go/schema"
   "github.com/hasura/ndc-sdk-go/utils"
 )
@@ -25,7 +26,7 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
     if err != nil {
 		  return err
     }
-  j.BigIntPtr = new(BigInt)
+  j.BigIntPtr = new(scalar.BigInt)
   err = functions_Decoder.DecodeNullableObjectValue(j.BigIntPtr, input, "BigIntPtr")
     if err != nil {
 		  return err
@@ -362,11 +363,6 @@ func (j HelloResult) ToMap() map[string]any {
   r["text"] = j.Text
 
 	return r
-}
-
-// ScalarName get the schema name of the scalar
-func (j BigInt) ScalarName() string {
-  return "BigInt"
 }
 
 // ScalarName get the schema name of the scalar

--- a/cmd/ndc-go-sdk/testdata/basic/expected/schema.json
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/schema.json
@@ -1067,7 +1067,7 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "type": "string"
+        "type": "biginteger"
       }
     },
     "Boolean": {
@@ -1123,7 +1123,7 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "type": "int32"
+        "type": "int64"
       }
     },
     "Int8": {

--- a/cmd/ndc-go-sdk/testdata/basic/source/functions/prefix.go
+++ b/cmd/ndc-go-sdk/testdata/basic/source/functions/prefix.go
@@ -8,14 +8,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hasura/ndc-codegen-test/types"
+	"github.com/hasura/ndc-sdk-go/scalar"
 )
 
 type Text string
-
-// BigInt a big integer
-//
-// @scalar string
-type BigInt string
 
 // A foo scalar
 type ScalarFoo struct {
@@ -105,7 +101,7 @@ type GetTypesArguments struct {
 	Text         Text
 	CustomScalar CommentText
 	Enum         SomeEnum
-	BigInt       BigInt
+	BigInt       scalar.BigInt
 
 	UUIDPtr         *uuid.UUID
 	BoolPtr         *bool
@@ -126,7 +122,7 @@ type GetTypesArguments struct {
 	TextPtr         *Text
 	CustomScalarPtr *CommentText
 	EnumPtr         *SomeEnum
-	BigIntPtr       *BigInt
+	BigIntPtr       *scalar.BigInt
 
 	Object struct {
 		ID        uuid.UUID `json:"id"`

--- a/example/codegen/functions/types.generated.go
+++ b/example/codegen/functions/types.generated.go
@@ -4,7 +4,6 @@ package functions
 import (
 	"encoding/json"
 	"errors"
-
 	"github.com/hasura/ndc-sdk-go/scalar"
 	"github.com/hasura/ndc-sdk-go/schema"
 	"github.com/hasura/ndc-sdk-go/utils"

--- a/example/codegen/schema.generated.json
+++ b/example/codegen/schema.generated.json
@@ -1106,7 +1106,7 @@
       "aggregate_functions": {},
       "comparison_operators": {},
       "representation": {
-        "type": "int64"
+        "type": "biginteger"
       }
     },
     "Boolean": {

--- a/scalar/bigint.go
+++ b/scalar/bigint.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hasura/ndc-sdk-go/utils"
 )
 
-// BigInt wraps the scalar implementation for 64-bit signed integer,
+// BigInt wraps the scalar implementation for big integer,
 // with string representation
 //
 // @scalar BigInt string

--- a/schema/scalar.go
+++ b/schema/scalar.go
@@ -52,6 +52,8 @@ const (
 	TypeRepresentationTypeFloat32 TypeRepresentationType = "float32"
 	// An IEEE-754 double-precision floating-point number
 	TypeRepresentationTypeFloat64 TypeRepresentationType = "float64"
+	// Arbitrary-precision integer string
+	TypeRepresentationTypeBigInteger TypeRepresentationType = "biginteger"
 	// Arbitrary-precision decimal string
 	TypeRepresentationTypeBigDecimal TypeRepresentationType = "bigdecimal"
 	// UUID string (8-4-4-4-12)
@@ -84,6 +86,7 @@ var enumValues_TypeRepresentationType = []TypeRepresentationType{
 	TypeRepresentationTypeInt64,
 	TypeRepresentationTypeFloat32,
 	TypeRepresentationTypeFloat64,
+	TypeRepresentationTypeBigInteger,
 	TypeRepresentationTypeBigDecimal,
 	TypeRepresentationTypeUUID,
 	TypeRepresentationTypeDate,
@@ -346,6 +349,21 @@ func (ty TypeRepresentation) AsFloat64() (*TypeRepresentationFloat64, error) {
 	}, nil
 }
 
+// AsBigInteger tries to convert the current type to TypeRepresentationBigInteger
+func (ty TypeRepresentation) AsBigInteger() (*TypeRepresentationBigInteger, error) {
+	t, err := ty.Type()
+	if err != nil {
+		return nil, err
+	}
+	if t != TypeRepresentationTypeBigInteger {
+		return nil, fmt.Errorf("invalid TypeRepresentation type; expected %s, got %s", TypeRepresentationTypeBigInteger, t)
+	}
+
+	return &TypeRepresentationBigInteger{
+		Type: t,
+	}, nil
+}
+
 // AsBigDecimal tries to convert the current type to TypeRepresentationBigDecimal
 func (ty TypeRepresentation) AsBigDecimal() (*TypeRepresentationBigDecimal, error) {
 	t, err := ty.Type()
@@ -549,6 +567,8 @@ func (ty TypeRepresentation) InterfaceT() (TypeRepresentationEncoder, error) {
 		return ty.AsFloat32()
 	case TypeRepresentationTypeFloat64:
 		return ty.AsFloat64()
+	case TypeRepresentationTypeBigInteger:
+		return ty.AsBigInteger()
 	case TypeRepresentationTypeBigDecimal:
 		return ty.AsBigDecimal()
 	case TypeRepresentationTypeUUID:
@@ -770,6 +790,25 @@ func NewTypeRepresentationFloat64() *TypeRepresentationFloat64 {
 
 // Encode returns the raw TypeRepresentation instance
 func (ty TypeRepresentationFloat64) Encode() TypeRepresentation {
+	return map[string]any{
+		"type": ty.Type,
+	}
+}
+
+// TypeRepresentationBigInteger represents an arbitrary-precision integer string
+type TypeRepresentationBigInteger struct {
+	Type TypeRepresentationType `json:"type" yaml:"type" mapstructure:"type"`
+}
+
+// NewTypeRepresentationBigInteger creates a new TypeRepresentationBigInteger instance
+func NewTypeRepresentationBigInteger() *TypeRepresentationBigInteger {
+	return &TypeRepresentationBigInteger{
+		Type: TypeRepresentationTypeBigInteger,
+	}
+}
+
+// Encode returns the raw TypeRepresentation instance
+func (ty TypeRepresentationBigInteger) Encode() TypeRepresentation {
 	return map[string]any{
 		"type": ty.Type,
 	}

--- a/schema/scalar_test.go
+++ b/schema/scalar_test.go
@@ -167,6 +167,18 @@ func TestTypeRepresentation(t *testing.T) {
 		assertDeepEqual(t, anyType, typeRep)
 	})
 
+	t.Run("big integer", func(t *testing.T) {
+		typeRep := NewTypeRepresentationBigInteger()
+		rawType := typeRep.Encode()
+
+		_, err := rawType.AsString()
+		assertError(t, err, "invalid TypeRepresentation type; expected string, got biginteger")
+
+		anyType, ok := rawType.Interface().(*TypeRepresentationBigInteger)
+		assertDeepEqual(t, true, ok)
+		assertDeepEqual(t, anyType, typeRep)
+	})
+
 	t.Run("big decimal", func(t *testing.T) {
 		typeRep := NewTypeRepresentationBigDecimal()
 		rawType := typeRep.Encode()

--- a/schema/schema.generated.json
+++ b/schema/schema.generated.json
@@ -426,6 +426,21 @@
           }
         },
         {
+          "description": "Arbitrary-precision integer string",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "biginteger"
+              ]
+            }
+          }
+        },
+        {
           "description": "Arbitrary-precision decimal string",
           "type": "object",
           "required": [


### PR DESCRIPTION
Adds a `biginteger` type representation, which is like `bigdecimal` but only contains integers.
This is useful to represent JavaScript's [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#bigint_type) type.