### PR TITLE
Support arbitrary JSON and bytes scalars

### DIFF
--- a/cmd/ndc-go-sdk/README.md
+++ b/cmd/ndc-go-sdk/README.md
@@ -198,6 +198,12 @@ The basic scalar types supported are:
 | Date        | scalar.Date                 | ISO 8601 date                                                                         | string              |
 | TimestampTZ | time.Time                   | ISO 8601 timestamp-with-timezone                                                      | string              |
 | Enum        |                             | Enumeration values                                                                    | string              |
+| Bytes       | scalar.Bytes                | Base64-encoded bytes                                                                  | string              |
+| JSON        | any, map[K]V                | Arbitrary JSON                                                                        | json                |
+| RawJSON     | json.RawMessage             | Raw arbitrary JSON                                                                    | json                |
+
+> [!NOTE]
+> We don't recommend to use the `RawJSON` scalar for `function` arguments because the decoder will re-encode the value to `[]byte` that isn't performance-wise.
 
 Alias scalar types will be inferred to the origin type in the schema.
 

--- a/cmd/ndc-go-sdk/connector.go
+++ b/cmd/ndc-go-sdk/connector.go
@@ -619,6 +619,14 @@ func (cg *connectorGenerator) genGetTypeValueDecoder(sb *connectorTypeBuilder, t
 		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetObjectUUID(input, "%s")`, fieldName, key))
 	case "*github.com/google/uuid.UUID":
 		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableObjectUUID(input, "%s")`, fieldName, key))
+	case "encoding/json.RawMessage":
+		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetObjectRawJSON(input, "%s")`, fieldName, key))
+	case "*encoding/json.RawMessage":
+		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableObjectRawJSON(input, "%s")`, fieldName, key))
+	case "any", "interface{}":
+		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetArbitraryJSON(input, "%s")`, fieldName, key))
+	case "*any", "*interface{}":
+		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableArbitraryJSON(input, "%s")`, fieldName, key))
 	default:
 		if ty.IsNullable() {
 			var pkgName, tyName string

--- a/cmd/ndc-go-sdk/testdata/basic/expected/functions.go.tmpl
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/functions.go.tmpl
@@ -7,12 +7,20 @@ import (
   "github.com/hasura/ndc-sdk-go/schema"
   "github.com/hasura/ndc-sdk-go/utils"
 )
-
 var functions_Decoder = utils.NewDecoder()
 
 // FromValue decodes values from map
 func (j *GetTypesArguments) FromValue(input map[string]any) error {
   var err error
+  err = functions_Decoder.DecodeObjectValue(&j.ArrayMap, input, "ArrayMap")
+    if err != nil {
+		  return err
+    }
+  j.ArrayMapPtr = new([]map[string]any)
+  err = functions_Decoder.DecodeNullableObjectValue(j.ArrayMapPtr, input, "ArrayMapPtr")
+    if err != nil {
+		  return err
+    }
   err = functions_Decoder.DecodeObjectValue(&j.ArrayObject, input, "ArrayObject")
     if err != nil {
 		  return err
@@ -39,6 +47,15 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
     if err != nil {
 		  return err
     }
+  err = functions_Decoder.DecodeObjectValue(&j.Bytes, input, "Bytes")
+    if err != nil {
+		  return err
+    }
+  j.BytesPtr = new(scalar.Bytes)
+  err = functions_Decoder.DecodeNullableObjectValue(j.BytesPtr, input, "BytesPtr")
+    if err != nil {
+		  return err
+    }
   err = functions_Decoder.DecodeObjectValue(&j.CustomScalar, input, "CustomScalar")
     if err != nil {
 		  return err
@@ -50,12 +67,12 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
     }
   err = functions_Decoder.DecodeObjectValue(&j.Enum, input, "Enum")
     if err != nil {
-      return err
+		  return err
     }
   j.EnumPtr = new(SomeEnum)
   err = functions_Decoder.DecodeNullableObjectValue(j.EnumPtr, input, "EnumPtr")
     if err != nil {
-      return err
+		  return err
     }
   j.Float32, err = utils.GetFloat[float32](input, "Float32")
     if err != nil {
@@ -113,6 +130,23 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
     if err != nil {
 		  return err
     }
+  j.JSON, err = utils.GetArbitraryJSON(input, "JSON")
+    if err != nil {
+		  return err
+    }
+  j.JSONPtr, err = utils.GetNullableArbitraryJSON(input, "JSONPtr")
+    if err != nil {
+		  return err
+    }
+  err = functions_Decoder.DecodeObjectValue(&j.Map, input, "Map")
+    if err != nil {
+		  return err
+    }
+  j.MapPtr = new(map[string]any)
+  err = functions_Decoder.DecodeNullableObjectValue(j.MapPtr, input, "MapPtr")
+    if err != nil {
+		  return err
+    }
   err = functions_Decoder.DecodeObjectValue(&j.NamedArray, input, "NamedArray")
     if err != nil {
 		  return err
@@ -137,6 +171,14 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
     }
   j.ObjectPtr = new(struct{Long int; Lat int})
   err = functions_Decoder.DecodeNullableObjectValue(j.ObjectPtr, input, "ObjectPtr")
+    if err != nil {
+		  return err
+    }
+  j.RawJSON, err = utils.GetObjectRawJSON(input, "RawJSON")
+    if err != nil {
+		  return err
+    }
+  j.RawJSONPtr, err = utils.GetNullableObjectRawJSON(input, "RawJSONPtr")
     if err != nil {
 		  return err
     }
@@ -268,6 +310,8 @@ func (j GetArticlesResult) ToMap() map[string]any {
 // ToMap encodes the struct to a value map
 func (j GetTypesArguments) ToMap() map[string]any {
   r := make(map[string]any)
+  r["ArrayMap"] = j.ArrayMap
+  r["ArrayMapPtr"] = j.ArrayMapPtr
   j_ArrayObject := make([]map[string]any, len(j.ArrayObject))
   for i, j_ArrayObject_v := range j.ArrayObject {
   j_ArrayObject_v_obj := make(map[string]any)
@@ -288,6 +332,8 @@ func (j GetTypesArguments) ToMap() map[string]any {
   r["BigIntPtr"] = j.BigIntPtr
   r["Bool"] = j.Bool
   r["BoolPtr"] = j.BoolPtr
+  r["Bytes"] = j.Bytes
+  r["BytesPtr"] = j.BytesPtr
   r["CustomScalar"] = j.CustomScalar
   r["CustomScalarPtr"] = j.CustomScalarPtr
   r["Enum"] = j.Enum
@@ -306,6 +352,10 @@ func (j GetTypesArguments) ToMap() map[string]any {
   r["Int8"] = j.Int8
   r["Int8Ptr"] = j.Int8Ptr
   r["IntPtr"] = j.IntPtr
+  r["JSON"] = j.JSON
+  r["JSONPtr"] = j.JSONPtr
+  r["Map"] = j.Map
+  r["MapPtr"] = j.MapPtr
   j_NamedArray := make([]map[string]any, len(j.NamedArray))
   for i, j_NamedArray_v := range j.NamedArray {
   j_NamedArray[i] = utils.EncodeMap(j_NamedArray_v)
@@ -332,6 +382,8 @@ func (j GetTypesArguments) ToMap() map[string]any {
   j_ObjectPtr__obj["Long"] = (*j.ObjectPtr).Long
   r["ObjectPtr"] = j_ObjectPtr__obj
   }
+  r["RawJSON"] = j.RawJSON
+  r["RawJSONPtr"] = j.RawJSONPtr
   r["String"] = j.String
   r["StringPtr"] = j.StringPtr
   r["Text"] = j.Text
@@ -364,7 +416,6 @@ func (j HelloResult) ToMap() map[string]any {
 
 	return r
 }
-
 // ScalarName get the schema name of the scalar
 func (j CommentText) ScalarName() string {
   return "CommentString"
@@ -374,14 +425,14 @@ func (j CommentText) ScalarName() string {
 func (j ScalarFoo) ScalarName() string {
   return "Foo"
 }
+
 // ScalarName get the schema name of the scalar
 func (j SomeEnum) ScalarName() string {
   return "SomeEnum"
 }
-
 const (
-	SomeEnumFoo SomeEnum = "foo"
-	SomeEnumBar SomeEnum = "bar"
+  SomeEnumFoo SomeEnum = "foo"
+  SomeEnumBar SomeEnum = "bar"
 )
 
 var enumValues_SomeEnum = []SomeEnum{SomeEnumFoo, SomeEnumBar}

--- a/cmd/ndc-go-sdk/testdata/basic/expected/schema.json
+++ b/cmd/ndc-go-sdk/testdata/basic/expected/schema.json
@@ -12,6 +12,27 @@
     },
     {
       "arguments": {
+        "ArrayMap": {
+          "type": {
+            "element_type": {
+              "name": "JSON",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "ArrayMapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
         "ArrayObject": {
           "type": {
             "element_type": {
@@ -59,6 +80,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "Boolean",
+              "type": "named"
+            }
+          }
+        },
+        "Bytes": {
+          "type": {
+            "name": "Bytes",
+            "type": "named"
+          }
+        },
+        "BytesPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Bytes",
               "type": "named"
             }
           }
@@ -198,6 +234,36 @@
             }
           }
         },
+        "JSON": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "JSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
+        "Map": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "MapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
         "NamedArray": {
           "type": {
             "element_type": {
@@ -245,6 +311,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "GetTypesArgumentsObjectPtr",
+              "type": "named"
+            }
+          }
+        },
+        "RawJSON": {
+          "type": {
+            "name": "RawJSON",
+            "type": "named"
+          }
+        },
+        "RawJSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "RawJSON",
               "type": "named"
             }
           }
@@ -527,6 +608,27 @@
     },
     "GetTypesArguments": {
       "fields": {
+        "ArrayMap": {
+          "type": {
+            "element_type": {
+              "name": "JSON",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "ArrayMapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
         "ArrayObject": {
           "type": {
             "element_type": {
@@ -574,6 +676,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "Boolean",
+              "type": "named"
+            }
+          }
+        },
+        "Bytes": {
+          "type": {
+            "name": "Bytes",
+            "type": "named"
+          }
+        },
+        "BytesPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Bytes",
               "type": "named"
             }
           }
@@ -713,6 +830,36 @@
             }
           }
         },
+        "JSON": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "JSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
+        "Map": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "MapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
         "NamedArray": {
           "type": {
             "element_type": {
@@ -760,6 +907,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "GetTypesArgumentsObjectPtr",
+              "type": "named"
+            }
+          }
+        },
+        "RawJSON": {
+          "type": {
+            "name": "RawJSON",
+            "type": "named"
+          }
+        },
+        "RawJSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "RawJSON",
               "type": "named"
             }
           }
@@ -1077,6 +1239,13 @@
         "type": "boolean"
       }
     },
+    "Bytes": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "bytes"
+      }
+    },
     "CommentString": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -1131,6 +1300,13 @@
       "comparison_operators": {},
       "representation": {
         "type": "int8"
+      }
+    },
+    "RawJSON": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
       }
     },
     "SomeEnum": {

--- a/cmd/ndc-go-sdk/testdata/basic/source/functions/prefix.go
+++ b/cmd/ndc-go-sdk/testdata/basic/source/functions/prefix.go
@@ -2,6 +2,7 @@ package functions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -143,6 +144,18 @@ type GetTypesArguments struct {
 	NamedArray     []Author
 	NamedArrayPtr  *[]Author
 	UUIDArray      []uuid.UUID
+
+	Map         map[string]any
+	MapPtr      *map[string]any
+	ArrayMap    []map[string]any
+	ArrayMapPtr *[]map[string]any
+
+	JSON       any
+	JSONPtr    *interface{}
+	RawJSON    json.RawMessage
+	RawJSONPtr *json.RawMessage
+	Bytes      scalar.Bytes
+	BytesPtr   *scalar.Bytes
 }
 
 func FunctionGetTypes(ctx context.Context, state *types.State, arguments *GetTypesArguments) (*GetTypesArguments, error) {

--- a/example/codegen/connector_test.go
+++ b/example/codegen/connector_test.go
@@ -293,6 +293,54 @@ func TestQueryGetTypes(t *testing.T) {
 							"b085b0b9-007c-440e-9661-0d8f2de98a5a",
 							"b085b0b9-007c-440e-9661-0d8f2de98a5b"
 						]
+					},
+					"Map": {
+						"type": "literal",
+						"value": {
+							"foo": "bar"
+						}
+					},
+					"MapPtr": {
+						"type": "literal",
+						"value": {
+							"foo": "bar_ptr"
+						}
+					},
+					"ArrayMap": {
+						"type": "literal",
+						"value": [{
+							"foo": "bar"
+						}]
+					},
+					"ArrayMapPtr": {
+						"type": "literal",
+						"value": [{
+							"foo": "bar_ptr"
+						}]
+					},
+					"JSON": {
+						"type": "literal",
+						"value": {"message":"json"}
+					},
+					"JSONPtr": {
+						"type": "literal",
+						"value": {"message":"json_ptr"}
+					},
+					"RawJSON": {
+						"type": "literal",
+						"value": {"message":"raw_json"}
+					},
+					"RawJSONPtr": {
+						"type": "literal",
+						"value": {"message":"raw_json_ptr"}
+					},
+					"Bytes": {
+						"type": "literal",
+						"value": "aGVsbG8gd29ybGQ="
+					},
+					"BytesPtr": {
+						"type": "literal",
+						"value": "aGVsbG8gcG9pbnRlcg=="
 					}
 				},
 				"query": {
@@ -612,6 +660,46 @@ func TestQueryGetTypes(t *testing.T) {
 									"UintPtr": {
 										"column": "UintPtr",
 										"type": "column"
+									},
+									"Map": {
+										"column": "Map",
+										"type": "column"
+									},
+									"MapPtr": {
+										"column": "MapPtr",
+										"type": "column"
+									},
+									"ArrayMap": {
+										"column": "ArrayMap",
+										"type": "column"
+									},
+									"ArrayMapPtr": {
+										"column": "ArrayMapPtr",
+										"type": "column"
+									},
+									"JSON": {
+										"column": "JSON",
+										"type": "column"
+									},
+									"JSONPtr": {
+										"column": "JSONPtr",
+										"type": "column"
+									},
+									"RawJSON": {
+										"column": "RawJSON",
+										"type": "column"
+									},
+									"RawJSONPtr": {
+										"column": "RawJSONPtr",
+										"type": "column"
+									},
+									"Bytes": {
+										"column": "Bytes",
+										"type": "column"
+									},
+									"BytesPtr": {
+										"column": "BytesPtr",
+										"type": "column"
 									}
 								},
 								"type": "object"
@@ -717,6 +805,24 @@ func TestQueryGetTypes(t *testing.T) {
 					uuid.MustParse("b085b0b9-007c-440e-9661-0d8f2de98a5a"),
 					uuid.MustParse("b085b0b9-007c-440e-9661-0d8f2de98a5b"),
 				},
+				Map: map[string]any{
+					"foo": "bar",
+				},
+				MapPtr: &map[string]any{
+					"foo": "bar_ptr",
+				},
+				ArrayMap: []map[string]any{
+					{"foo": "bar"},
+				},
+				ArrayMapPtr: &[]map[string]any{
+					{"foo": "bar_ptr"},
+				},
+				JSON:       map[string]any{"message": "json"},
+				JSONPtr:    utils.ToPtr(any(map[string]any{"message": "json_ptr"})),
+				RawJSON:    json.RawMessage(`{"message":"raw_json"}`),
+				RawJSONPtr: utils.ToPtr(json.RawMessage(`{"message":"raw_json_ptr"}`)),
+				Bytes:      *scalar.NewBytes([]byte("hello world")),
+				BytesPtr:   scalar.NewBytes([]byte("hello pointer")),
 			},
 		},
 	}

--- a/example/codegen/functions/prefix.go
+++ b/example/codegen/functions/prefix.go
@@ -150,6 +150,18 @@ type GetTypesArguments struct {
 	NamedArray     []Author
 	NamedArrayPtr  *[]Author
 	UUIDArray      []uuid.UUID
+
+	Map         map[string]any
+	MapPtr      *map[string]any
+	ArrayMap    []map[string]any
+	ArrayMapPtr *[]map[string]any
+
+	JSON       any
+	JSONPtr    *interface{}
+	RawJSON    json.RawMessage
+	RawJSONPtr *json.RawMessage
+	Bytes      scalar.Bytes
+	BytesPtr   *scalar.Bytes
 }
 
 func FunctionGetTypes(ctx context.Context, state *types.State, arguments *GetTypesArguments) (*GetTypesArguments, error) {

--- a/example/codegen/functions/types.generated.go
+++ b/example/codegen/functions/types.generated.go
@@ -14,6 +14,15 @@ var functions_Decoder = utils.NewDecoder()
 // FromValue decodes values from map
 func (j *GetTypesArguments) FromValue(input map[string]any) error {
 	var err error
+	err = functions_Decoder.DecodeObjectValue(&j.ArrayMap, input, "ArrayMap")
+	if err != nil {
+		return err
+	}
+	j.ArrayMapPtr = new([]map[string]any)
+	err = functions_Decoder.DecodeNullableObjectValue(j.ArrayMapPtr, input, "ArrayMapPtr")
+	if err != nil {
+		return err
+	}
 	err = functions_Decoder.DecodeObjectValue(&j.ArrayObject, input, "ArrayObject")
 	if err != nil {
 		return err
@@ -39,6 +48,15 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 		return err
 	}
 	j.BoolPtr, err = utils.GetNullableBool(input, "BoolPtr")
+	if err != nil {
+		return err
+	}
+	err = functions_Decoder.DecodeObjectValue(&j.Bytes, input, "Bytes")
+	if err != nil {
+		return err
+	}
+	j.BytesPtr = new(scalar.Bytes)
+	err = functions_Decoder.DecodeNullableObjectValue(j.BytesPtr, input, "BytesPtr")
 	if err != nil {
 		return err
 	}
@@ -125,6 +143,23 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 	if err != nil {
 		return err
 	}
+	j.JSON, err = utils.GetArbitraryJSON(input, "JSON")
+	if err != nil {
+		return err
+	}
+	j.JSONPtr, err = utils.GetNullableArbitraryJSON(input, "JSONPtr")
+	if err != nil {
+		return err
+	}
+	err = functions_Decoder.DecodeObjectValue(&j.Map, input, "Map")
+	if err != nil {
+		return err
+	}
+	j.MapPtr = new(map[string]any)
+	err = functions_Decoder.DecodeNullableObjectValue(j.MapPtr, input, "MapPtr")
+	if err != nil {
+		return err
+	}
 	err = functions_Decoder.DecodeObjectValue(&j.NamedArray, input, "NamedArray")
 	if err != nil {
 		return err
@@ -152,6 +187,14 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 		Lat  int
 	})
 	err = functions_Decoder.DecodeNullableObjectValue(j.ObjectPtr, input, "ObjectPtr")
+	if err != nil {
+		return err
+	}
+	j.RawJSON, err = utils.GetObjectRawJSON(input, "RawJSON")
+	if err != nil {
+		return err
+	}
+	j.RawJSONPtr, err = utils.GetNullableObjectRawJSON(input, "RawJSONPtr")
 	if err != nil {
 		return err
 	}
@@ -290,6 +333,8 @@ func (j GetArticlesResult) ToMap() map[string]any {
 // ToMap encodes the struct to a value map
 func (j GetTypesArguments) ToMap() map[string]any {
 	r := make(map[string]any)
+	r["ArrayMap"] = j.ArrayMap
+	r["ArrayMapPtr"] = j.ArrayMapPtr
 	j_ArrayObject := make([]map[string]any, len(j.ArrayObject))
 	for i, j_ArrayObject_v := range j.ArrayObject {
 		j_ArrayObject_v_obj := make(map[string]any)
@@ -310,6 +355,8 @@ func (j GetTypesArguments) ToMap() map[string]any {
 	r["BigIntPtr"] = j.BigIntPtr
 	r["Bool"] = j.Bool
 	r["BoolPtr"] = j.BoolPtr
+	r["Bytes"] = j.Bytes
+	r["BytesPtr"] = j.BytesPtr
 	r["CustomScalar"] = j.CustomScalar
 	r["CustomScalarPtr"] = j.CustomScalarPtr
 	r["Date"] = j.Date
@@ -330,6 +377,10 @@ func (j GetTypesArguments) ToMap() map[string]any {
 	r["Int8"] = j.Int8
 	r["Int8Ptr"] = j.Int8Ptr
 	r["IntPtr"] = j.IntPtr
+	r["JSON"] = j.JSON
+	r["JSONPtr"] = j.JSONPtr
+	r["Map"] = j.Map
+	r["MapPtr"] = j.MapPtr
 	j_NamedArray := make([]map[string]any, len(j.NamedArray))
 	for i, j_NamedArray_v := range j.NamedArray {
 		j_NamedArray[i] = utils.EncodeMap(j_NamedArray_v)
@@ -356,6 +407,8 @@ func (j GetTypesArguments) ToMap() map[string]any {
 		j_ObjectPtr__obj["Long"] = (*j.ObjectPtr).Long
 		r["ObjectPtr"] = j_ObjectPtr__obj
 	}
+	r["RawJSON"] = j.RawJSON
+	r["RawJSONPtr"] = j.RawJSONPtr
 	r["String"] = j.String
 	r["StringPtr"] = j.StringPtr
 	r["Text"] = j.Text

--- a/example/codegen/schema.generated.json
+++ b/example/codegen/schema.generated.json
@@ -12,6 +12,27 @@
     },
     {
       "arguments": {
+        "ArrayMap": {
+          "type": {
+            "element_type": {
+              "name": "JSON",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "ArrayMapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
         "ArrayObject": {
           "type": {
             "element_type": {
@@ -59,6 +80,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "Boolean",
+              "type": "named"
+            }
+          }
+        },
+        "Bytes": {
+          "type": {
+            "name": "Bytes",
+            "type": "named"
+          }
+        },
+        "BytesPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Bytes",
               "type": "named"
             }
           }
@@ -213,6 +249,36 @@
             }
           }
         },
+        "JSON": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "JSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
+        "Map": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "MapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
         "NamedArray": {
           "type": {
             "element_type": {
@@ -260,6 +326,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "GetTypesArgumentsObjectPtr",
+              "type": "named"
+            }
+          }
+        },
+        "RawJSON": {
+          "type": {
+            "name": "RawJSON",
+            "type": "named"
+          }
+        },
+        "RawJSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "RawJSON",
               "type": "named"
             }
           }
@@ -551,6 +632,27 @@
     },
     "GetTypesArguments": {
       "fields": {
+        "ArrayMap": {
+          "type": {
+            "element_type": {
+              "name": "JSON",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        },
+        "ArrayMapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
         "ArrayObject": {
           "type": {
             "element_type": {
@@ -598,6 +700,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "Boolean",
+              "type": "named"
+            }
+          }
+        },
+        "Bytes": {
+          "type": {
+            "name": "Bytes",
+            "type": "named"
+          }
+        },
+        "BytesPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Bytes",
               "type": "named"
             }
           }
@@ -752,6 +869,36 @@
             }
           }
         },
+        "JSON": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "JSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
+        "Map": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "MapPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
+          }
+        },
         "NamedArray": {
           "type": {
             "element_type": {
@@ -799,6 +946,21 @@
             "type": "nullable",
             "underlying_type": {
               "name": "GetTypesArgumentsObjectPtr",
+              "type": "named"
+            }
+          }
+        },
+        "RawJSON": {
+          "type": {
+            "name": "RawJSON",
+            "type": "named"
+          }
+        },
+        "RawJSONPtr": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "RawJSON",
               "type": "named"
             }
           }
@@ -1116,6 +1278,13 @@
         "type": "boolean"
       }
     },
+    "Bytes": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "bytes"
+      }
+    },
     "CommentString": {
       "aggregate_functions": {},
       "comparison_operators": {},
@@ -1177,6 +1346,13 @@
       "comparison_operators": {},
       "representation": {
         "type": "int8"
+      }
+    },
+    "RawJSON": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "json"
       }
     },
     "SomeEnum": {

--- a/scalar/bigint_test.go
+++ b/scalar/bigint_test.go
@@ -43,8 +43,16 @@ func TestBigInt(t *testing.T) {
 		t.Error("expected error, got nil")
 		t.FailNow()
 	}
-	if err := json.Unmarshal([]byte(""), &value1); err == nil {
-		t.Error("expected error, got nil")
+
+	if err := json.Unmarshal([]byte("null"), &value1); err != nil {
+		t.Errorf("expected nil, got error: %v", err)
 		t.FailNow()
+	}
+
+	for _, b := range [][]byte{[]byte(""), []byte(`"abc"`)} {
+		if err := json.Unmarshal(b, &value1); err == nil {
+			t.Error("expected error, got nil")
+			t.FailNow()
+		}
 	}
 }

--- a/scalar/bytes.go
+++ b/scalar/bytes.go
@@ -1,0 +1,76 @@
+package scalar
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/hasura/ndc-sdk-go/utils"
+)
+
+// Bytes wraps the scalar implementation for bytes with base64 encoding
+//
+// @scalar Bytes string
+type Bytes struct {
+	data []byte
+}
+
+// NewBytes create a Bytes instance
+func NewBytes(data []byte) *Bytes {
+	return &Bytes{data: data}
+}
+
+// ParseBytes parses bytes from base64 string
+func ParseBytes(value string) (*Bytes, error) {
+	bs, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Bytes{data: bs}, nil
+}
+
+// Bytes implements fmt.Stringer interface.
+func (bs Bytes) String() string {
+	return string(bs.data)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (bs Bytes) MarshalJSON() ([]byte, error) {
+	str := base64.StdEncoding.EncodeToString(bs.data)
+	return json.Marshal(str)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (bs *Bytes) UnmarshalJSON(b []byte) error {
+	var value string
+	if err := json.Unmarshal(b, &value); err != nil {
+		return err
+	}
+
+	result, err := ParseBytes(value)
+	if err != nil {
+		return err
+	}
+	*bs = *result
+
+	return nil
+}
+
+// FromValue decode any value to d Date.
+func (bs *Bytes) FromValue(value any) error {
+	sValue, err := utils.DecodeNullableString(value)
+	if err != nil {
+		return err
+	}
+	if sValue == nil {
+		return nil
+	}
+
+	data, err := base64.StdEncoding.DecodeString(*sValue)
+	if err != nil {
+		return err
+	}
+	bs.data = data
+
+	return nil
+}

--- a/scalar/bytes.go
+++ b/scalar/bytes.go
@@ -29,7 +29,17 @@ func ParseBytes(value string) (*Bytes, error) {
 	return &Bytes{data: bs}, nil
 }
 
-// Bytes implements fmt.Stringer interface.
+// Bytes get the inner bytes value.
+func (bs Bytes) Bytes() []byte {
+	return bs.data
+}
+
+// Bytes get the inner bytes length.
+func (bs Bytes) Len() int {
+	return len(bs.data)
+}
+
+// String implements fmt.Stringer interface.
 func (bs Bytes) String() string {
 	return string(bs.data)
 }

--- a/scalar/bytes_test.go
+++ b/scalar/bytes_test.go
@@ -51,6 +51,11 @@ func TestBytes(t *testing.T) {
 		t.FailNow()
 	}
 
+	if value1.Len() != len(value1.Bytes()) {
+		t.Errorf("expected equal bytes length, got: %d != %d", value1.Len(), len(value1.Bytes()))
+		t.FailNow()
+	}
+
 	if err := value1.FromValue(0); err == nil {
 		t.Error("expected error, got nil")
 		t.FailNow()

--- a/scalar/bytes_test.go
+++ b/scalar/bytes_test.go
@@ -1,0 +1,75 @@
+package scalar
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestBytes(t *testing.T) {
+	plain := "Hello world"
+	expected := NewBytes([]byte(plain))
+	expectedB64 := base64.StdEncoding.EncodeToString([]byte(plain))
+
+	rawJSON := fmt.Sprintf(`"%s"`, expectedB64)
+	var value Bytes
+	if err := json.Unmarshal([]byte(rawJSON), &value); err != nil {
+		t.Errorf("failed to parse Bytes: %s", err)
+		t.FailNow()
+	}
+	if plain != value.String() {
+		t.Errorf("expected: %s, got: %s", expected, value)
+		t.FailNow()
+	}
+	rawValue, err := json.Marshal(value)
+	if err != nil {
+		t.Errorf("failed to encode Bytes: %s", err)
+		t.FailNow()
+	}
+
+	if string(expectedB64) != strings.Trim(string(rawValue), "\"") {
+		t.Errorf("expected: %s, got: %s", expected, string(rawValue))
+		t.FailNow()
+	}
+
+	var value1 Bytes
+
+	if err := value1.FromValue(nil); err != nil {
+		t.Errorf("expected nil, got error: %s", err)
+		t.FailNow()
+	}
+
+	if err := value1.FromValue(expectedB64); err != nil {
+		t.Errorf("expected nil, got error: %s", err)
+		t.FailNow()
+	}
+
+	if value1.String() != plain {
+		t.Errorf("expected: %s, got: %s", expected, value1)
+		t.FailNow()
+	}
+
+	if err := value1.FromValue(0); err == nil {
+		t.Error("expected error, got nil")
+		t.FailNow()
+	}
+
+	if err := value1.FromValue("abc"); err == nil {
+		t.Error("expected error, got nil")
+		t.FailNow()
+	}
+
+	for _, b := range [][]byte{[]byte(""), []byte("0"), []byte(`"abc"`)} {
+		if err := json.Unmarshal(b, &value1); err == nil {
+			t.Error("expected error, got nil")
+			t.FailNow()
+		}
+	}
+
+	if _, err := ParseBytes("abc"); err == nil {
+		t.Error("expected error, got nil")
+		t.FailNow()
+	}
+}

--- a/scalar/date_test.go
+++ b/scalar/date_test.go
@@ -45,7 +45,27 @@ func TestDate(t *testing.T) {
 		t.Error("expected error, got nil")
 		t.FailNow()
 	}
-	if err := json.Unmarshal([]byte(""), &value1); err == nil {
+
+	if err := value1.FromValue(0); err == nil {
+		t.Error("expected error, got nil")
+		t.FailNow()
+	}
+
+	if err := value1.FromValue(nil); err != nil {
+		t.Errorf("expected no error, got %v", err)
+		t.FailNow()
+	}
+
+	if err := json.Unmarshal([]byte(`"abc"`), &value1); err == nil {
+		t.Error("expected error, got nil")
+		t.FailNow()
+	}
+
+	if err := json.Unmarshal([]byte("0"), &value1); err == nil {
+		t.Error("expected error, got nil")
+		t.FailNow()
+	}
+	if _, err := ParseDate(""); err == nil {
 		t.Error("expected error, got nil")
 		t.FailNow()
 	}

--- a/utils/decode.go
+++ b/utils/decode.go
@@ -661,9 +661,17 @@ func GetAny(object map[string]any, key string) (any, bool) {
 // GetNullableArbitraryJSON get an arbitrary json pointer from object by key
 func GetNullableArbitraryJSON(object map[string]any, key string) (*any, error) {
 	value, ok := GetAny(object, key)
-	if !ok {
+	if !ok || value == nil {
 		return nil, nil
 	}
+	reflectValue := reflect.ValueOf(value)
+	if reflectValue.Kind() != reflect.Pointer {
+		return &value, nil
+	}
+	if reflectValue.IsNil() {
+		return nil, nil
+	}
+	value = reflectValue.Elem().Interface()
 	return &value, nil
 }
 

--- a/utils/decode_test.go
+++ b/utils/decode_test.go
@@ -601,4 +601,19 @@ func TestDecodeNestedInterface(t *testing.T) {
 	assertNoError(t, err)
 	assertEqual(t, fmt.Sprint(1.1), fmt.Sprint(f))
 
+	j, err := GetArbitraryJSON(arrItem, "int")
+	assertNoError(t, err)
+	assertEqual(t, 1, j)
+
+	jp, err := GetNullableArbitraryJSON(arrItem, "int")
+	assertNoError(t, err)
+	assertEqual(t, 1, *jp)
+
+	jp, err = GetNullableArbitraryJSON(arrItem, "floatPtr")
+	assertNoError(t, err)
+	assertEqual(t, fmt.Sprint(1.1), fmt.Sprint(*jp))
+
+	jp, err = GetNullableArbitraryJSON(arrItem, "not_exist")
+	assertNoError(t, err)
+	assertEqual(t, true, jp == nil)
 }


### PR DESCRIPTION
- Add arbitrary JSON scalars for `any` and `map[K]V`
- Add `RawJSON` scalar for `json.RawMessage`
- Add `scalar.Bytes` scalar for Base64-encoded bytes