### PR TITLE
Fix object generation from 3rd packages, self-reference & alias selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ clean:
 	rm -f cmd/hasura-ndc-go/testdata/*/source/schema.generated.json
 	rm -f cmd/hasura-ndc-go/testdata/*/source/**/schema.generated.json
 	rm -f cmd/hasura-ndc-go/testdata/*/source/**/types.generated.go
-	rm -rf cmd/hasura-ndc-go/testdata/*/source/testdata
+	rm -rf cmd/hasura-ndc-go/testdata/**/testdata
 
 .PHONY: build-codegen
 build-codegen:

--- a/cmd/hasura-ndc-go/testdata/basic/expected/functions.go.tmpl
+++ b/cmd/hasura-ndc-go/testdata/basic/expected/functions.go.tmpl
@@ -3,7 +3,6 @@ package functions
 import (
   "encoding/json"
   "errors"
-  "fmt"
   "github.com/google/uuid"
   "github.com/hasura/ndc-sdk-go/scalar"
   "github.com/hasura/ndc-sdk-go/schema"
@@ -598,48 +597,44 @@ func (j *GetArticlesArguments) FromValue(input map[string]any) error {
   return nil
 }
 // ToMap encodes the struct to a value map
-func (j Author) ToMap() (map[string]any, error) {
+func (j Author) ToMap() map[string]any {
   r := make(map[string]any)
   r["created_at"] = j.CreatedAt
   r["id"] = j.ID
 
-	return r, nil
+	return r
 }
 // ToMap encodes the struct to a value map
-func (j CreateArticleResult) ToMap() (map[string]any, error) {
+func (j CreateArticleResult) ToMap() map[string]any {
   r := make(map[string]any)
-  j_Authors := make([]map[string]any, len(j.Authors))
+  j_Authors := make([]any, len(j.Authors))
   for i, j_Authors_v := range j.Authors {
-  itemResult, err := utils.EncodeObject(j_Authors_v)
-  if err != nil {
-    return nil, fmt.Errorf("failed to encode Authors: %s", err)
-	}
-  j_Authors[i] = itemResult
+  j_Authors[i] = j_Authors_v
 		  }
   r["authors"] = j_Authors
   r["id"] = j.ID
 
-	return r, nil
+	return r
 }
 // ToMap encodes the struct to a value map
-func (j CreateAuthorResult) ToMap() (map[string]any, error) {
+func (j CreateAuthorResult) ToMap() map[string]any {
   r := make(map[string]any)
   r["created_at"] = j.CreatedAt
   r["id"] = j.ID
   r["name"] = j.Name
 
-	return r, nil
+	return r
 }
 // ToMap encodes the struct to a value map
-func (j GetArticlesResult) ToMap() (map[string]any, error) {
+func (j GetArticlesResult) ToMap() map[string]any {
   r := make(map[string]any)
   r["id"] = j.ID
   r["Name"] = j.Name
 
-	return r, nil
+	return r
 }
 // ToMap encodes the struct to a value map
-func (j GetTypesArguments) ToMap() (map[string]any, error) {
+func (j GetTypesArguments) ToMap() map[string]any {
   r := make(map[string]any)
   r["ArrayBigInt"] = j.ArrayBigInt
   r["ArrayBigIntPtr"] = j.ArrayBigIntPtr
@@ -663,7 +658,7 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
   r["ArrayJSONPtr"] = j.ArrayJSONPtr
   r["ArrayMap"] = j.ArrayMap
   r["ArrayMapPtr"] = j.ArrayMapPtr
-  j_ArrayObject := make([]map[string]any, len(j.ArrayObject))
+  j_ArrayObject := make([]any, len(j.ArrayObject))
   for i, j_ArrayObject_v := range j.ArrayObject {
   j_ArrayObject_v_obj := make(map[string]any)
   j_ArrayObject_v_obj["content"] = j_ArrayObject_v.Content
@@ -671,7 +666,7 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
   }
   r["ArrayObject"] = j_ArrayObject
   if j.ArrayObjectPtr != nil {
-  j_ArrayObjectPtr := make([]map[string]any, len((*j.ArrayObjectPtr)))
+  j_ArrayObjectPtr := make([]any, len((*j.ArrayObjectPtr)))
   for i, j_ArrayObjectPtr_v := range (*j.ArrayObjectPtr) {
   j_ArrayObjectPtr_v_obj := make(map[string]any)
   j_ArrayObjectPtr_v_obj["content"] = j_ArrayObjectPtr_v.Content
@@ -725,37 +720,21 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
   r["JSONPtr"] = j.JSONPtr
   r["Map"] = j.Map
   r["MapPtr"] = j.MapPtr
-  j_NamedArray := make([]map[string]any, len(j.NamedArray))
+  j_NamedArray := make([]any, len(j.NamedArray))
   for i, j_NamedArray_v := range j.NamedArray {
-  itemResult, err := utils.EncodeObject(j_NamedArray_v)
-  if err != nil {
-    return nil, fmt.Errorf("failed to encode NamedArray: %s", err)
-	}
-  j_NamedArray[i] = itemResult
+  j_NamedArray[i] = j_NamedArray_v
 		  }
   r["NamedArray"] = j_NamedArray
   if j.NamedArrayPtr != nil {
-  j_NamedArrayPtr := make([]map[string]any, len((*j.NamedArrayPtr)))
+  j_NamedArrayPtr := make([]any, len((*j.NamedArrayPtr)))
   for i, j_NamedArrayPtr_v := range (*j.NamedArrayPtr) {
-  itemResult, err := utils.EncodeObject(j_NamedArrayPtr_v)
-  if err != nil {
-    return nil, fmt.Errorf("failed to encode NamedArrayPtr: %s", err)
-	}
-  j_NamedArrayPtr[i] = itemResult
+  j_NamedArrayPtr[i] = j_NamedArrayPtr_v
 		  }
   r["NamedArrayPtr"] = j_NamedArrayPtr
   }
-  itemResult, err := utils.EncodeObject(j.NamedObject)
-  if err != nil {
-    return nil, fmt.Errorf("failed to encode NamedObject: %s", err)
-	}
-  r["NamedObject"] = itemResult
+  r["NamedObject"] = j.NamedObject
 		  if j.NamedObjectPtr != nil {
-  itemResult, err := utils.EncodeObject((*j.NamedObjectPtr))
-  if err != nil {
-    return nil, fmt.Errorf("failed to encode NamedObjectPtr: %s", err)
-	}
-  r["NamedObjectPtr"] = itemResult
+  r["NamedObjectPtr"] = (*j.NamedObjectPtr)
 		  }
   j_Object_obj := make(map[string]any)
   j_Object_obj["created_at"] = j.Object.CreatedAt
@@ -827,17 +806,17 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
   r["Uint8Ptr"] = j.Uint8Ptr
   r["UintPtr"] = j.UintPtr
 
-	return r, nil
+	return r
 }
 // ToMap encodes the struct to a value map
-func (j HelloResult) ToMap() (map[string]any, error) {
+func (j HelloResult) ToMap() map[string]any {
   r := make(map[string]any)
   r["foo"] = j.Foo
   r["id"] = j.ID
   r["num"] = j.Num
   r["text"] = j.Text
 
-	return r, nil
+	return r
 }
 // ScalarName get the schema name of the scalar
 func (j CommentText) ScalarName() string {

--- a/cmd/hasura-ndc-go/testdata/subdir/expected/functions.go.tmpl
+++ b/cmd/hasura-ndc-go/testdata/subdir/expected/functions.go.tmpl
@@ -8,6 +8,10 @@ var functions_Decoder = utils.NewDecoder()
 // FromValue decodes values from map
 func (j *GetArticlesArguments) FromValue(input map[string]any) error {
   var err error
+  err = functions_Decoder.DecodeObjectValue(&j.Author, input, "Author")
+    if err != nil {
+		  return err
+    }
   j.Limit, err = utils.GetFloat[float64](input, "Limit")
     if err != nil {
 		  return err
@@ -15,9 +19,10 @@ func (j *GetArticlesArguments) FromValue(input map[string]any) error {
   return nil
 }
 // ToMap encodes the struct to a value map
-func (j GetArticlesResult) ToMap() (map[string]any, error) {
+func (j GetArticlesResult) ToMap() map[string]any {
   r := make(map[string]any)
-  r["id"] = j.ID
+  r["Author"] = j.Author
+		  r["id"] = j.ID
 
-	return r, nil
+	return r
 }

--- a/cmd/hasura-ndc-go/testdata/subdir/expected/schema.json
+++ b/cmd/hasura-ndc-go/testdata/subdir/expected/schema.json
@@ -3,6 +3,12 @@
   "functions": [
     {
       "arguments": {
+        "Author": {
+          "type": {
+            "name": "Author",
+            "type": "named"
+          }
+        },
         "Limit": {
           "type": {
             "name": "Float64",
@@ -22,8 +28,48 @@
     }
   ],
   "object_types": {
+    "Author": {
+      "fields": {
+        "author": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Author",
+              "type": "named"
+            }
+          }
+        },
+        "created_at": {
+          "type": {
+            "name": "TimestampTZ",
+            "type": "named"
+          }
+        },
+        "id": {
+          "type": {
+            "name": "String",
+            "type": "named"
+          }
+        },
+        "tags": {
+          "type": {
+            "element_type": {
+              "name": "String",
+              "type": "named"
+            },
+            "type": "array"
+          }
+        }
+      }
+    },
     "GetArticlesResult": {
       "fields": {
+        "Author": {
+          "type": {
+            "name": "Author",
+            "type": "named"
+          }
+        },
         "id": {
           "type": {
             "name": "String",
@@ -47,6 +93,13 @@
       "comparison_operators": {},
       "representation": {
         "type": "string"
+      }
+    },
+    "TimestampTZ": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "timestamptz"
       }
     }
   }

--- a/cmd/hasura-ndc-go/testdata/subdir/source/connector/functions/comment.go
+++ b/cmd/hasura-ndc-go/testdata/subdir/source/connector/functions/comment.go
@@ -3,15 +3,18 @@ package functions
 import (
 	"context"
 
+	example "github.com/hasura/ndc-codegen-example/types"
 	"github.com/hasura/ndc-codegen-subdir-test/types"
 )
 
 type GetArticlesArguments struct {
 	Limit float64
+	example.Author
 }
 
 type GetArticlesResult struct {
 	ID string `json:"id"`
+	example.Author
 }
 
 // GetArticles

--- a/cmd/hasura-ndc-go/testdata/subdir/source/go.mod
+++ b/cmd/hasura-ndc-go/testdata/subdir/source/go.mod
@@ -3,10 +3,11 @@ module github.com/hasura/ndc-codegen-subdir-test
 go 1.19
 
 require (
-	github.com/hasura/ndc-sdk-go v0.6.0
+	github.com/hasura/ndc-sdk-go v0.6.2
 	github.com/rs/zerolog v1.33.0
 	go.opentelemetry.io/otel v1.17.0
 	go.opentelemetry.io/otel/trace v1.17.0
+	github.com/hasura/ndc-codegen-example v0.6.2
 )
 
 require (
@@ -50,3 +51,5 @@ require (
 )
 
 replace github.com/hasura/ndc-sdk-go => ../../../../../
+
+replace github.com/hasura/ndc-codegen-example => ../../../../../example/codegen

--- a/example/codegen/connector_test.go
+++ b/example/codegen/connector_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hasura/ndc-sdk-go/connector"
 	"github.com/hasura/ndc-sdk-go/scalar"
 	"github.com/hasura/ndc-sdk-go/utils"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +24,7 @@ func createTestServer(t *testing.T) *connector.Server[types.Configuration, types
 	server, err := connector.NewServer[types.Configuration, types.State](&Connector{}, &connector.ServerOptions{
 		Configuration: "{}",
 		InlineConfig:  true,
-	}, connector.WithoutRecovery())
+	}, connector.WithoutRecovery(), connector.WithLogger(zerolog.Nop()))
 
 	assert.NoError(t, err)
 

--- a/example/codegen/functions/types.generated.go
+++ b/example/codegen/functions/types.generated.go
@@ -2,7 +2,6 @@
 package functions
 
 import (
-	"fmt"
 	"github.com/hasura/ndc-sdk-go/utils"
 )
 
@@ -19,50 +18,46 @@ func (j *GetArticlesArguments) FromValue(input map[string]any) error {
 }
 
 // ToMap encodes the struct to a value map
-func (j CreateArticleResult) ToMap() (map[string]any, error) {
+func (j CreateArticleResult) ToMap() map[string]any {
 	r := make(map[string]any)
-	j_Authors := make([]map[string]any, len(j.Authors))
+	j_Authors := make([]any, len(j.Authors))
 	for i, j_Authors_v := range j.Authors {
-		itemResult, err := utils.EncodeObject(j_Authors_v)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode Authors: %s", err)
-		}
-		j_Authors[i] = itemResult
+		j_Authors[i] = j_Authors_v
 	}
 	r["authors"] = j_Authors
 	r["id"] = j.ID
 
-	return r, nil
+	return r
 }
 
 // ToMap encodes the struct to a value map
-func (j CreateAuthorResult) ToMap() (map[string]any, error) {
+func (j CreateAuthorResult) ToMap() map[string]any {
 	r := make(map[string]any)
 	r["created_at"] = j.CreatedAt
 	r["id"] = j.ID
 	r["name"] = j.Name
 
-	return r, nil
+	return r
 }
 
 // ToMap encodes the struct to a value map
-func (j GetArticlesResult) ToMap() (map[string]any, error) {
+func (j GetArticlesResult) ToMap() map[string]any {
 	r := make(map[string]any)
 	r["id"] = j.ID
 	r["Name"] = j.Name
 
-	return r, nil
+	return r
 }
 
 // ToMap encodes the struct to a value map
-func (j HelloResult) ToMap() (map[string]any, error) {
+func (j HelloResult) ToMap() map[string]any {
 	r := make(map[string]any)
 	r["foo"] = j.Foo
 	r["id"] = j.ID
 	r["num"] = j.Num
 	r["text"] = j.Text
 
-	return r, nil
+	return r
 }
 
 // ScalarName get the schema name of the scalar

--- a/example/codegen/schema.generated.json
+++ b/example/codegen/schema.generated.json
@@ -1437,6 +1437,15 @@
   "object_types": {
     "Author": {
       "fields": {
+        "author": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Author",
+              "type": "named"
+            }
+          }
+        },
         "created_at": {
           "type": {
             "name": "TimestampTZ",

--- a/example/codegen/types/arguments/types.generated.go
+++ b/example/codegen/types/arguments/types.generated.go
@@ -3,7 +3,6 @@ package arguments
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/google/uuid"
 	"github.com/hasura/ndc-codegen-example/types"
 	"github.com/hasura/ndc-sdk-go/scalar"
@@ -601,7 +600,7 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 }
 
 // ToMap encodes the struct to a value map
-func (j GetTypesArguments) ToMap() (map[string]any, error) {
+func (j GetTypesArguments) ToMap() map[string]any {
 	r := make(map[string]any)
 	r["ArrayBigInt"] = j.ArrayBigInt
 	r["ArrayBigIntPtr"] = j.ArrayBigIntPtr
@@ -625,7 +624,7 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
 	r["ArrayJSONPtr"] = j.ArrayJSONPtr
 	r["ArrayMap"] = j.ArrayMap
 	r["ArrayMapPtr"] = j.ArrayMapPtr
-	j_ArrayObject := make([]map[string]any, len(j.ArrayObject))
+	j_ArrayObject := make([]any, len(j.ArrayObject))
 	for i, j_ArrayObject_v := range j.ArrayObject {
 		j_ArrayObject_v_obj := make(map[string]any)
 		j_ArrayObject_v_obj["content"] = j_ArrayObject_v.Content
@@ -633,7 +632,7 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
 	}
 	r["ArrayObject"] = j_ArrayObject
 	if j.ArrayObjectPtr != nil {
-		j_ArrayObjectPtr := make([]map[string]any, len((*j.ArrayObjectPtr)))
+		j_ArrayObjectPtr := make([]any, len((*j.ArrayObjectPtr)))
 		for i, j_ArrayObjectPtr_v := range *j.ArrayObjectPtr {
 			j_ArrayObjectPtr_v_obj := make(map[string]any)
 			j_ArrayObjectPtr_v_obj["content"] = j_ArrayObjectPtr_v.Content
@@ -689,37 +688,21 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
 	r["JSONPtr"] = j.JSONPtr
 	r["Map"] = j.Map
 	r["MapPtr"] = j.MapPtr
-	j_NamedArray := make([]map[string]any, len(j.NamedArray))
+	j_NamedArray := make([]any, len(j.NamedArray))
 	for i, j_NamedArray_v := range j.NamedArray {
-		itemResult, err := utils.EncodeObject(j_NamedArray_v)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode NamedArray: %s", err)
-		}
-		j_NamedArray[i] = itemResult
+		j_NamedArray[i] = j_NamedArray_v
 	}
 	r["NamedArray"] = j_NamedArray
 	if j.NamedArrayPtr != nil {
-		j_NamedArrayPtr := make([]map[string]any, len((*j.NamedArrayPtr)))
+		j_NamedArrayPtr := make([]any, len((*j.NamedArrayPtr)))
 		for i, j_NamedArrayPtr_v := range *j.NamedArrayPtr {
-			itemResult, err := utils.EncodeObject(j_NamedArrayPtr_v)
-			if err != nil {
-				return nil, fmt.Errorf("failed to encode NamedArrayPtr: %s", err)
-			}
-			j_NamedArrayPtr[i] = itemResult
+			j_NamedArrayPtr[i] = j_NamedArrayPtr_v
 		}
 		r["NamedArrayPtr"] = j_NamedArrayPtr
 	}
-	itemResult, err := utils.EncodeObject(j.NamedObject)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode NamedObject: %s", err)
-	}
-	r["NamedObject"] = itemResult
+	r["NamedObject"] = j.NamedObject
 	if j.NamedObjectPtr != nil {
-		itemResult, err := utils.EncodeObject((*j.NamedObjectPtr))
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode NamedObjectPtr: %s", err)
-		}
-		r["NamedObjectPtr"] = itemResult
+		r["NamedObjectPtr"] = (*j.NamedObjectPtr)
 	}
 	j_Object_obj := make(map[string]any)
 	j_Object_obj["created_at"] = j.Object.CreatedAt
@@ -790,5 +773,5 @@ func (j GetTypesArguments) ToMap() (map[string]any, error) {
 	r["Uint8Ptr"] = j.Uint8Ptr
 	r["UintPtr"] = j.UintPtr
 
-	return r, nil
+	return r
 }

--- a/example/codegen/types/types.generated.go
+++ b/example/codegen/types/types.generated.go
@@ -11,13 +11,16 @@ import (
 var types_Decoder = utils.NewDecoder()
 
 // ToMap encodes the struct to a value map
-func (j Author) ToMap() (map[string]any, error) {
+func (j Author) ToMap() map[string]any {
 	r := make(map[string]any)
+	if j.Author != nil {
+		r["author"] = (*j.Author)
+	}
 	r["created_at"] = j.CreatedAt
 	r["id"] = j.ID
 	r["tags"] = j.Tags
 
-	return r, nil
+	return r
 }
 
 // ScalarName get the schema name of the scalar

--- a/example/codegen/types/types.go
+++ b/example/codegen/types/types.go
@@ -43,4 +43,5 @@ type Author struct {
 	ID        string    `json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 	Tags      []string  `json:"tags"`
+	Author    *Author   `json:"author"`
 }

--- a/utils/connector.go
+++ b/utils/connector.go
@@ -165,12 +165,12 @@ func evalObjectWithColumnSelection(fields map[string]schema.Field, data map[stri
 					if err != nil {
 						return nil, err
 					}
-					output[fi.Column] = nestedValue
+					output[key] = nestedValue
 				} else {
-					output[fi.Column] = col
+					output[key] = col
 				}
 			} else {
-				output[fi.Column] = nil
+				output[key] = nil
 			}
 		case *schema.RelationshipField:
 			return nil, &schema.ErrorResponse{

--- a/utils/connector_test.go
+++ b/utils/connector_test.go
@@ -88,6 +88,42 @@ func TestEvalNestedFields(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "rename_fields",
+			Input: struct {
+				ID       string `json:"id"`
+				Name     string `json:"name"`
+				Articles []struct {
+					Name string
+				} `json:"articles"`
+			}{
+				ID:   "1",
+				Name: "John",
+				Articles: []struct {
+					Name string
+				}{
+					{
+						Name: "Article 1",
+					},
+				},
+			},
+			Selection: schema.NewNestedObject(map[string]schema.FieldEncoder{
+				"id":   schema.NewColumnField("id", nil),
+				"Name": schema.NewColumnField("name", nil),
+				"articles": schema.NewColumnField("articles", schema.NewNestedArray(schema.NewNestedObject(map[string]schema.FieldEncoder{
+					"name": schema.NewColumnField("Name", nil),
+				}))),
+			}).Encode(),
+			Expected: map[string]any{
+				"id":   "1",
+				"Name": "John",
+				"articles": []map[string]any{
+					{
+						"name": "Article 1",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/utils/decode.go
+++ b/utils/decode.go
@@ -104,11 +104,7 @@ func (d Decoder) decodeValue(target any, value any) error {
 		case map[string]any:
 			return t.FromValue(v)
 		case MapEncoder:
-			object, err := v.ToMap()
-			if err != nil {
-				return err
-			}
-			return t.FromValue(object)
+			return t.FromValue(v.ToMap())
 		default:
 			return errors.New("the value must be an object-liked")
 		}
@@ -1290,11 +1286,7 @@ func decodeValueHookFunc() mapstructure.DecodeHookFunc {
 			case map[string]any:
 				err = objDecoder.FromValue(v)
 			case MapEncoder:
-				object, toMapErr := v.ToMap()
-				if toMapErr != nil {
-					return nil, toMapErr
-				}
-				mapValue := object
+				mapValue := v.ToMap()
 				err = objDecoder.FromValue(mapValue)
 			}
 			if err != nil {

--- a/utils/encode.go
+++ b/utils/encode.go
@@ -11,7 +11,42 @@ import (
 
 // MapEncoder abstracts a type with the ToMap method to encode type to map
 type MapEncoder interface {
-	ToMap() (map[string]any, error)
+	ToMap() map[string]any
+}
+
+// EncodeMap encodes an object to a map[string]any, using json tag to convert object keys
+//
+// Deprecated: use EncodeObject instead
+func EncodeMap[T MapEncoder](input T) map[string]any {
+	if IsNil(input) {
+		return nil
+	}
+	return input.ToMap()
+}
+
+// EncodeMaps encode objects to a slice of map[string]any, using json tag to convert object keys
+//
+// Deprecated: use EncodeObjectSlice instead
+func EncodeMaps[T MapEncoder](inputs []T) []map[string]any {
+	var results []map[string]any
+	for _, item := range inputs {
+		results = append(results, item.ToMap())
+	}
+	return results
+}
+
+// EncodeNullableMaps encode objects to a slice of map[string]any, using json tag to convert object keys
+//
+// Deprecated: use EncodeNullableObjectSlice instead
+func EncodeNullableMaps[T MapEncoder](inputs *[]T) []map[string]any {
+	if inputs == nil {
+		return nil
+	}
+	var results []map[string]any
+	for _, item := range *inputs {
+		results = append(results, item.ToMap())
+	}
+	return results
 }
 
 // EncodeObject encodes an unknown type to a map[string]any, using json tag to convert object keys
@@ -53,7 +88,7 @@ func encodeObject(input any, fieldPath string) (map[string]any, error) {
 	case map[string]any:
 		return value, nil
 	case MapEncoder:
-		return value.ToMap()
+		return value.ToMap(), nil
 	case Scalar:
 		return nil, &schema.ErrorResponse{
 			Message: "cannot encode scalar to object",
@@ -75,7 +110,11 @@ func encodeObject(input any, fieldPath string) (map[string]any, error) {
 		kind := inputValue.Kind()
 		switch kind {
 		case reflect.Pointer:
-			return encodeObject(inputValue.Elem().Interface(), fieldPath)
+			v, ok := UnwrapPointerFromReflectValue(inputValue)
+			if !ok {
+				return nil, nil
+			}
+			return encodeObject(v.Interface(), fieldPath)
 		case reflect.Struct:
 			return encodeStruct(inputValue), nil
 		default:
@@ -171,10 +210,10 @@ func EncodeObjects(input any) ([]map[string]any, error) {
 }
 
 func encodeObjects(input any, fieldPath string) ([]map[string]any, error) {
-	if IsNil(input) {
+	inputValue, ok := UnwrapPointerFromReflectValue(reflect.ValueOf(input))
+	if !ok {
 		return nil, nil
 	}
-	inputValue := reflect.ValueOf(input)
 	inputKind := inputValue.Kind()
 	if inputKind != reflect.Array && inputKind != reflect.Slice {
 		return nil, &schema.ErrorResponse{

--- a/utils/encode_test.go
+++ b/utils/encode_test.go
@@ -1,0 +1,149 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/hasura/ndc-sdk-go/schema"
+)
+
+type mockAuthor struct {
+	ID        string  `json:"id"`
+	FirstName string  `json:"first_name"`
+	LastName  *string `json:"last_name"`
+	Address   struct {
+		Street string `json:"street"`
+	} `json:"address"`
+}
+
+func (ma mockAuthor) ToMap() (map[string]any, error) {
+	result := map[string]any{}
+	result["id"] = ma.ID
+	result["first_name"] = ma.FirstName
+	result["last_name"] = ma.LastName
+	result["address"] = map[string]any{
+		"street": ma.Address.Street,
+	}
+	return result, nil
+}
+
+type mockArticle struct {
+	ID      int          `json:"id"`
+	Authors []mockAuthor `json:"authors"`
+}
+
+func (ma mockArticle) ToMap() (map[string]any, error) {
+	result := map[string]any{}
+	result["id"] = ma.ID
+	authors := make([]map[string]any, len(ma.Authors))
+	for i, author := range ma.Authors {
+		au, err := author.ToMap()
+		if err != nil {
+			return nil, err
+		}
+		authors[i] = au
+	}
+	result["authors"] = authors
+	return result, nil
+}
+
+type mockArticleLazy mockArticle
+
+func (ma mockArticleLazy) ToMap() (map[string]any, error) {
+	result := map[string]any{}
+	result["id"] = ma.ID
+	result["authors"] = ma.Authors
+	return result, nil
+}
+
+var benchmarkEvalNestedColumnFixture = mockArticle{
+	ID: 1,
+	Authors: []mockAuthor{
+		{
+			ID:        "1",
+			FirstName: "Luke",
+			LastName:  ToPtr("Skywalker"),
+		},
+	},
+}
+
+var benchmarkEvalSingleFieldSelection = schema.NewNestedObject(map[string]schema.FieldEncoder{
+	"id": schema.NewColumnField("id", nil),
+}).Encode()
+
+var benchmarkEvalAllFieldsSelection = schema.NewNestedObject(map[string]schema.FieldEncoder{
+	"id": schema.NewColumnField("id", nil),
+	"authors": schema.NewColumnField("authors", schema.NewNestedArray(schema.NewNestedObject(map[string]schema.FieldEncoder{
+		"id":         schema.NewColumnField("id", nil),
+		"first_name": schema.NewColumnField("first_name", nil),
+		"last_name":  schema.NewColumnField("last_name", nil),
+		"address": schema.NewColumnField("address", schema.NewNestedObject(map[string]schema.FieldEncoder{
+			"street": schema.NewColumnField("street", nil),
+		})),
+	}))),
+}).Encode()
+
+// BenchmarkEvalSingleFieldToMap-32    	 1390357	       797.6 ns/op	    1512 B/op	      15 allocs/op
+func BenchmarkEvalSingleFieldToMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := EvalNestedColumnFields(benchmarkEvalSingleFieldSelection, benchmarkEvalNestedColumnFixture)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// BenchmarkEvalSingleFieldToMapLazy-32    	 2420421	       491.2 ns/op	     800 B/op	       8 allocs/op
+func BenchmarkEvalSingleFieldToMapLazy(b *testing.B) {
+	value := mockArticleLazy(benchmarkEvalNestedColumnFixture)
+	for i := 0; i < b.N; i++ {
+		_, err := EvalNestedColumnFields(benchmarkEvalSingleFieldSelection, value)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// BenchmarkEvalSingleFieldAny-32    	  706143	      1596 ns/op	    1776 B/op	      26 allocs/op
+func BenchmarkEvalSingleFieldAny(b *testing.B) {
+	type Object mockArticle
+	var object = Object(benchmarkEvalNestedColumnFixture)
+	for i := 0; i < b.N; i++ {
+		_, err := EvalNestedColumnFields(benchmarkEvalSingleFieldSelection, object)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// BenchmarkEvalAllFieldToMap-32    	  478923	      2319 ns/op	    2708 B/op	      38 allocs/op
+func BenchmarkEvalAllFieldToMap(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := EvalNestedColumnFields(benchmarkEvalAllFieldsSelection, benchmarkEvalNestedColumnFixture)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// BenchmarkEvalAllFieldToMapLazy-32    	  461304	      2345 ns/op	    2764 B/op	      38 allocs/op
+func BenchmarkEvalAllFieldToMapLazy(b *testing.B) {
+	value := mockArticleLazy(benchmarkEvalNestedColumnFixture)
+	for i := 0; i < b.N; i++ {
+		_, err := EvalNestedColumnFields(benchmarkEvalAllFieldsSelection, value)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// BenchmarkEvalAllFieldAny-32    	  368212	      3279 ns/op	    2972 B/op	      49 allocs/op
+func BenchmarkEvalAllFieldAny(b *testing.B) {
+	type Object mockArticle
+	var object = Object(benchmarkEvalNestedColumnFixture)
+	for i := 0; i < b.N; i++ {
+		_, err := EvalNestedColumnFields(benchmarkEvalAllFieldsSelection, object)
+		if err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
- Revert `ToMap` interface
- No longer generate nested named types in `ToMap`. Make it lazy for better encoding performance
- Fix object generation from 3rd packages
- Fix infinite loop in self-reference generation
- Fix field selection alias 