### PR TITLE
Bump ndc-spec v0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ All functions of the Connector interface are analogous to their Rust counterpart
 
 ## Features
 
-The SDK fully supports [NDC Specification v0.1.4](https://hasura.github.io/ndc-spec/specification/changelog.html#014) and [Connector Deployment spec](https://github.com/hasura/ndc-hub/blob/main/rfcs/0000-deployment.md) with following features:
+The SDK fully supports [NDC Specification v0.1.5](https://hasura.github.io/ndc-spec/specification/changelog.html#015) and [Connector Deployment spec](https://github.com/hasura/ndc-hub/blob/main/rfcs/0000-deployment.md) with following features:
 
 - Connector HTTP server
 - Authentication

--- a/cmd/hasura-ndc-go/templates/new/connector.go.tmpl
+++ b/cmd/hasura-ndc-go/templates/new/connector.go.tmpl
@@ -9,7 +9,7 @@ import (
 )
 
 var connectorCapabilities = schema.CapabilitiesResponse{
-	Version: "0.1.4",
+	Version: "0.1.5",
 	Capabilities: schema.Capabilities{
 		Query: schema.QueryCapabilities{
 			Variables:    schema.LeafCapability{},

--- a/cmd/hasura-ndc-go/testdata/basic/source/connector.go
+++ b/cmd/hasura-ndc-go/testdata/basic/source/connector.go
@@ -9,7 +9,7 @@ import (
 )
 
 var connectorCapabilities = schema.CapabilitiesResponse{
-	Version: "0.1.4",
+	Version: "0.1.5",
 	Capabilities: schema.Capabilities{
 		Query: schema.QueryCapabilities{
 			Variables: schema.LeafCapability{},

--- a/cmd/hasura-ndc-go/testdata/empty/source/connector.go
+++ b/cmd/hasura-ndc-go/testdata/empty/source/connector.go
@@ -9,7 +9,7 @@ import (
 )
 
 var connectorCapabilities = schema.CapabilitiesResponse{
-	Version: "0.1.4",
+	Version: "0.1.5",
 	Capabilities: schema.Capabilities{
 		Query: schema.QueryCapabilities{
 			Variables: schema.LeafCapability{},

--- a/cmd/hasura-ndc-go/testdata/subdir/source/connector/connector.go
+++ b/cmd/hasura-ndc-go/testdata/subdir/source/connector/connector.go
@@ -9,7 +9,7 @@ import (
 )
 
 var connectorCapabilities = schema.CapabilitiesResponse{
-	Version: "0.1.4",
+	Version: "0.1.5",
 	Capabilities: schema.Capabilities{
 		Query: schema.QueryCapabilities{
 			Variables: schema.LeafCapability{},

--- a/example/codegen/connector.go
+++ b/example/codegen/connector.go
@@ -9,7 +9,7 @@ import (
 )
 
 var connectorCapabilities = schema.CapabilitiesResponse{
-	Version: "0.1.4",
+	Version: "0.1.5",
 	Capabilities: schema.Capabilities{
 		Query: schema.QueryCapabilities{
 			Variables:    schema.LeafCapability{},

--- a/example/codegen/test.sh
+++ b/example/codegen/test.sh
@@ -8,7 +8,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 mkdir -p ./dist
 
 if [ ! -f ./dist/ndc-test ]; then
-  curl -L https://github.com/hasura/ndc-spec/releases/download/v0.1.4/ndc-test-x86_64-unknown-linux-gnu -o ./dist/ndc-test
+  curl -L https://github.com/hasura/ndc-spec/releases/download/v0.1.5/ndc-test-x86_64-unknown-linux-gnu -o ./dist/ndc-test
   chmod +x ./dist/ndc-test
 fi
 

--- a/example/codegen/testdata/capabilities
+++ b/example/codegen/testdata/capabilities
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "capabilities": {
     "query": {
       "variables": {}

--- a/example/reference/connector.go
+++ b/example/reference/connector.go
@@ -112,7 +112,7 @@ func (mc *Connector) HealthCheck(ctx context.Context, configuration *Configurati
 
 func (mc *Connector) GetCapabilities(configuration *Configuration) schema.CapabilitiesResponseMarshaler {
 	return &schema.CapabilitiesResponse{
-		Version: "0.1.4",
+		Version: "0.1.5",
 		Capabilities: schema.Capabilities{
 			Query: schema.QueryCapabilities{
 				Aggregates: schema.LeafCapability{},

--- a/example/reference/connector_test.go
+++ b/example/reference/connector_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const test_SpecVersion = "v0.1.4"
+const test_SpecVersion = "v0.1.5"
 
 func createTestServer(t *testing.T) *connector.Server[Configuration, State] {
 	server, err := connector.NewServer[Configuration, State](&Connector{}, &connector.ServerOptions{

--- a/example/reference/testdata/capabilities
+++ b/example/reference/testdata/capabilities
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.4",
+  "version": "0.1.5",
   "capabilities": {
     "query": {
       "aggregates": {},


### PR DESCRIPTION
There is no change in the schema. It's still safe to use v0.1.4