### PR TITLE
Implement custom json.Marshaler for RowSet

### DIFF
--- a/example/reference/connector_test.go
+++ b/example/reference/connector_test.go
@@ -299,9 +299,9 @@ func TestQuery(t *testing.T) {
 			responseURL: fmt.Sprintf("https://raw.githubusercontent.com/hasura/ndc-spec/%s/ndc-reference/tests/query/predicate_with_unrelated_exists/expected.json", test_SpecVersion),
 		},
 		{
-			name:       "predicate_with_unrelated_exists_and_relationship",
-			requestURL: fmt.Sprintf("https://raw.githubusercontent.com/hasura/ndc-spec/%s/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/request.json", test_SpecVersion),
-			response:   []byte(`[{"rows":[{"author_if_has_functional_articles":{},"title":"The Next 700 Programming Languages"},{"author_if_has_functional_articles":{"rows":[{"articles":{"rows":[{"title":"Why Functional Programming Matters"},{"title":"The Design And Implementation Of Programming Languages"}]},"first_name":"John","last_name":"Hughes"}]},"title":"Why Functional Programming Matters"},{"author_if_has_functional_articles":{"rows":[{"articles":{"rows":[{"title":"Why Functional Programming Matters"},{"title":"The Design And Implementation Of Programming Languages"}]},"first_name":"John","last_name":"Hughes"}]},"title":"The Design And Implementation Of Programming Languages"}]}]`),
+			name:        "predicate_with_unrelated_exists_and_relationship",
+			requestURL:  fmt.Sprintf("https://raw.githubusercontent.com/hasura/ndc-spec/%s/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/request.json", test_SpecVersion),
+			responseURL: fmt.Sprintf("https://raw.githubusercontent.com/hasura/ndc-spec/%s/ndc-reference/tests/query/predicate_with_unrelated_exists_and_relationship/expected.json", test_SpecVersion),
 		},
 		{
 			name:        "star_count",

--- a/example/reference/go.mod.build
+++ b/example/reference/go.mod.build
@@ -3,5 +3,5 @@ module github.com/hasura/ndc-sdk-go-reference
 go 1.21
 
 require (
-	github.com/hasura/ndc-sdk-go v1.3.0
+	github.com/hasura/ndc-sdk-go v1.4.0
 )

--- a/schema/query.go
+++ b/schema/query.go
@@ -6,6 +6,19 @@ import (
 	"fmt"
 )
 
+// MarshalJSON implements json.Marshaler.
+func (j RowSet) MarshalJSON() ([]byte, error) {
+	result := map[string]any{}
+	if len(j.Aggregates) > 0 {
+		result["aggregates"] = j.Aggregates
+	}
+	if j.Rows != nil {
+		result["rows"] = j.Rows
+	}
+
+	return json.Marshal(result)
+}
+
 // UnmarshalJSONMap decodes FunctionInfo from a JSON map.
 func (j *FunctionInfo) UnmarshalJSONMap(raw map[string]json.RawMessage) error {
 	rawArguments, ok := raw["arguments"]


### PR DESCRIPTION
Implement the custom `json.Marshaler` for `RowSet`. The `rows` field is omitted only if its value is null.