### PR TITLE
cli: support omitempty and ignore json tags

### DIFF
--- a/cmd/hasura-ndc-go/README.md
+++ b/cmd/hasura-ndc-go/README.md
@@ -168,6 +168,11 @@ the schema will be:
 }
 ```
 
+JSON tag options are also supported:
+
+- `omitempty`: if this option is set, the field schema will be nullable even if the field type isn't a pointer.
+- `-`: the object field is ignored.
+
 #### Arguments
 
 Arguments must be defined as struct types. The generator automatically infers argument types in functions to generate schemas and Encoder and Decoder methods. Value fields are treated as required and pointer fields are optional.

--- a/cmd/hasura-ndc-go/command/internal/connector.go
+++ b/cmd/hasura-ndc-go/command/internal/connector.go
@@ -286,7 +286,7 @@ func (j %s) ToMap() map[string]any {
 `, object.Type.String()))
 		cg.writeObjectToMap(sb, &object, "j", "r")
 		sb.builder.WriteString(`
-	return r
+  return r
 }`)
 	}
 
@@ -398,51 +398,51 @@ var enumValues_%s = []%s{%s}
 			sb.builder.WriteString(fmt.Sprintf(`
 // Parse%s parses a %s enum from string
 func Parse%s(input string) (%s, error) {
-	result := %s(input)
-	if !slices.Contains(enumValues_%s, result) {
-		return %s(""), errors.New("failed to parse %s, expect one of %s")
-	}
+  result := %s(input)
+  if !slices.Contains(enumValues_%s, result) {
+    return %s(""), errors.New("failed to parse %s, expect one of %s")
+  }
 
-	return result, nil
+  return result, nil
 }
 
 // IsValid checks if the value is invalid
 func (j %s) IsValid() bool {
-	return slices.Contains(enumValues_%s, j)
+  return slices.Contains(enumValues_%s, j)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *%s) UnmarshalJSON(b []byte) error {
-	var rawValue string
-	if err := json.Unmarshal(b, &rawValue); err != nil {
-		return err
-	}
+  var rawValue string
+  if err := json.Unmarshal(b, &rawValue); err != nil {
+    return err
+  }
 
-	value, err := Parse%s(rawValue)
-	if err != nil {
-		return err
-	}
+  value, err := Parse%s(rawValue)
+  if err != nil {
+    return err
+  }
 
-	*j = value
-	return nil
+  *j = value
+  return nil
 }
 
 // FromValue decodes the scalar from an unknown value
 func (s *%s) FromValue(value any) error {
-	valueStr, err := utils.DecodeNullableString(value)
-	if err != nil {
-		return err
-	}
-	if valueStr == nil {
-		return nil
-	}
-	result, err := Parse%s(*valueStr)
-	if err != nil {
-		return err
-	}
+  valueStr, err := utils.DecodeNullableString(value)
+  if err != nil {
+    return err
+  }
+  if valueStr == nil {
+    return nil
+  }
+  result, err := Parse%s(*valueStr)
+  if err != nil {
+    return err
+  }
 
-	*s = result
-	return nil
+  *s = result
+  return nil
 }
 `, pascalName, scalarKey, pascalName, scalarKey, scalarKey, pascalName, scalarKey, scalarKey, strings.Join(enumConstants, ", "),
 				scalarKey, pascalName, scalarKey, pascalName, scalarKey, pascalName,
@@ -484,7 +484,9 @@ func (j *`)
 	argumentKeys := utils.GetSortedKeys(info.Fields)
 	for _, key := range argumentKeys {
 		arg := info.Fields[key]
-		cg.writeGetTypeValueDecoder(sb, &arg, key)
+		schemaField := info.SchemaFields[key]
+
+		cg.writeGetTypeValueDecoder(sb, &arg, schemaField, key)
 	}
 	sb.builder.WriteString("  return nil\n}")
 }
@@ -539,7 +541,7 @@ func (cg *connectorGenerator) genConnectorHandlers() {
 	}
 }
 
-func (cg *connectorGenerator) writeGetTypeValueDecoder(sb *connectorTypeBuilder, field *Field, key string) {
+func (cg *connectorGenerator) writeGetTypeValueDecoder(sb *connectorTypeBuilder, field *Field, objectField schema.ObjectField, key string) {
 	ty := field.Type
 	fieldName := field.Name
 	typeName := ty.String()
@@ -550,95 +552,95 @@ func (cg *connectorGenerator) writeGetTypeValueDecoder(sb *connectorTypeBuilder,
 
 	switch fullTypeName {
 	case "bool":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetBoolean(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetBoolean", "", key, objectField, false)
 	case "[]bool":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetBooleanSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetBooleanSlice", "", key, objectField, false)
 	case "*bool":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableBoolean(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableBoolean", "", key, objectField, true)
 	case "[]*bool":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetBooleanPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetBooleanPtrSlice", "", key, objectField, false)
 	case "*[]*bool":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableBooleanPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableBooleanPtrSlice", "", key, objectField, true)
 	case "string":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetString(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetString", "", key, objectField, false)
 	case "[]string":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetStringSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetStringSlice", "", key, objectField, false)
 	case "*string":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableString(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableString", "", key, objectField, true)
 	case "[]*string":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetStringPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetStringPtrSlice", "", key, objectField, false)
 	case "*[]*string":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableStringPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableStringPtrSlice", "", key, objectField, true)
 	case "int", "int8", "int16", "int32", "int64", "rune", "byte":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetInt[%s](input, "%s")`, fieldName, typeName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetInt", typeName, key, objectField, false)
 	case "[]int", "[]int8", "[]int16", "[]int32", "[]int64", "[]rune", "[]byte":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetIntSlice[%s](input, "%s")`, fieldName, typeName[2:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetIntSlice", typeName[2:], key, objectField, false)
 	case "uint", "uint8", "uint16", "uint32", "uint64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetUint[%s](input, "%s")`, fieldName, typeName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetUint", typeName, key, objectField, false)
 	case "[]uint", "[]uint8", "[]uint16", "[]uint32", "[]uint64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetUintSlice[%s](input, "%s")`, fieldName, typeName[2:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetUintSlice", typeName[2:], key, objectField, false)
 	case "*int", "*int8", "*int16", "*int32", "*int64", "*rune", "*byte":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableInt[%s](input, "%s")`, fieldName, typeName[1:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableInt", typeName[1:], key, objectField, true)
 	case "[]*int", "[]*int8", "[]*int16", "[]*int32", "[]*int64", "[]*rune", "[]*byte":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetIntPtrSlice[%s](input, "%s")`, fieldName, typeName[3:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetIntPtrSlice", typeName[3:], key, objectField, false)
 	case "*uint", "*uint8", "*uint16", "*uint32", "*uint64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableUint[%s](input, "%s")`, fieldName, typeName[1:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableUint", typeName[1:], key, objectField, true)
 	case "[]*uint", "[]*uint8", "[]*uint16", "[]*uint32", "[]*uint64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetUintPtrSlice[%s](input, "%s")`, fieldName, typeName[3:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetUintPtrSlice", typeName[3:], key, objectField, false)
 	case "*[]*int", "*[]*int8", "*[]*int16", "*[]*int32", "*[]*int64", "*[]*rune", "*[]*byte":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableIntPtrSlice[%s](input, "%s")`, fieldName, typeName[4:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableIntPtrSlice", typeName[4:], key, objectField, true)
 	case "*[]*uint", "*[]*uint8", "*[]*uint16", "*[]*uint32", "*[]*uint64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableUintPtrSlice[%s](input, "%s")`, fieldName, typeName[4:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableUintPtrSlice", typeName[4:], key, objectField, true)
 	case "float32", "float64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetFloat[%s](input, "%s")`, fieldName, typeName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetFloat", typeName, key, objectField, false)
 	case "[]float32", "[]float64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetFloatSlice[%s](input, "%s")`, fieldName, typeName[2:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetFloatSlice", typeName[2:], key, objectField, false)
 	case "*float32", "*float64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableFloat[%s](input, "%s")`, fieldName, typeName[1:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableFloat", typeName[1:], key, objectField, true)
 	case "[]*float32", "[]*float64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetFloatPtrSlice[%s](input, "%s")`, fieldName, typeName[3:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetFloatPtrSlice", typeName[3:], key, objectField, false)
 	case "*[]*float32", "*[]*float64":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableFloatPtrSlice[%s](input, "%s")`, fieldName, typeName[4:], key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableFloatPtrSlice", typeName[4:], key, objectField, true)
 	case "time.Time":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetDateTime(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetDateTime", "", key, objectField, false)
 	case "[]time.Time":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetDateTimeSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetDateTimeSlice", "", key, objectField, false)
 	case "*time.Time":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableDateTime(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableDateTime", "", key, objectField, true)
 	case "[]*time.Time":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetDateTimePtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetDateTimePtrSlice", "", key, objectField, false)
 	case "*[]*time.Time":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableDateTimePtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableDateTimePtrSlice", "", key, objectField, true)
 	case "github.com/google/uuid.UUID":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetUUID(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetUUID", "", key, objectField, false)
 	case "[]github.com/google/uuid.UUID":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetUUIDSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetUUIDSlice", "", key, objectField, false)
 	case "*github.com/google/uuid.UUID":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableUUID(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableUUID", "", key, objectField, true)
 	case "[]*github.com/google/uuid.UUID":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetUUIDPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetUUIDPtrSlice", "", key, objectField, false)
 	case "*[]*github.com/google/uuid.UUID":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableUUIDPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableUUIDPtrSlice", "", key, objectField, true)
 	case "encoding/json.RawMessage":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetRawJSON(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetRawJSON", "", key, objectField, false)
 	case "[]encoding/json.RawMessage":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetRawJSONSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetRawJSONSlice", "", key, objectField, false)
 	case "*encoding/json.RawMessage":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableRawJSON(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableRawJSON", "", key, objectField, true)
 	case "[]*encoding/json.RawMessage":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetRawJSONPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetRawJSONPtrSlice", "", key, objectField, false)
 	case "*[]*encoding/json.RawMessage":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableRawJSONPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableRawJSONPtrSlice", "", key, objectField, true)
 	case "any", "interface{}":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetArbitraryJSON(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetArbitraryJSON", "", key, objectField, false)
 	case "[]any", "[]interface{}":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetArbitraryJSONSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetArbitraryJSONSlice", "", key, objectField, false)
 	case "*any", "*interface{}":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableArbitraryJSON(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableArbitraryJSON", "", key, objectField, true)
 	case "[]*any", "[]*interface{}":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetArbitraryJSONPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetArbitraryJSONPtrSlice", "", key, objectField, false)
 	case "*[]*any", "*[]*interface{}":
-		sb.builder.WriteString(fmt.Sprintf(`  j.%s, err = utils.GetNullableArbitraryJSONPtrSlice(input, "%s")`, fieldName, key))
+		cg.writeScalarDecodeValue(sb, fieldName, "GetNullableArbitraryJSONPtrSlice", "", key, objectField, true)
 	default:
 		switch t := ty.(type) {
 		case *NullableType:
@@ -665,12 +667,24 @@ func (cg *connectorGenerator) writeGetTypeValueDecoder(sb *connectorTypeBuilder,
 				sb.builder.WriteString(`")`)
 			}
 		default:
+			var canEmpty bool
+			if len(objectField.Type) > 0 {
+				if typeEnum, err := objectField.Type.Type(); err == nil && typeEnum == schema.TypeNullable {
+					canEmpty = true
+				}
+			}
 			if field.Embedded {
 				sb.builder.WriteString("  err = connector_Decoder.DecodeObject(&j.")
 				sb.builder.WriteString(fieldName)
 				sb.builder.WriteString(", input)")
 			} else {
-				sb.builder.WriteString("  err = connector_Decoder.DecodeObjectValue(&j.")
+				sb.builder.WriteString("  err = connector_Decoder.")
+				if canEmpty {
+					sb.builder.WriteString("DecodeNullableObjectValue")
+				} else {
+					sb.builder.WriteString("DecodeObjectValue")
+				}
+				sb.builder.WriteString("(&j.")
 				sb.builder.WriteString(fieldName)
 				sb.builder.WriteString(`, input, "`)
 				sb.builder.WriteString(key)
@@ -678,7 +692,27 @@ func (cg *connectorGenerator) writeGetTypeValueDecoder(sb *connectorTypeBuilder,
 			}
 		}
 	}
-	sb.builder.WriteString(textBlockErrorCheck)
+	writeErrorCheck(sb.builder, 1, 2)
+}
+
+func (cg *connectorGenerator) writeScalarDecodeValue(sb *connectorTypeBuilder, fieldName, functionName, typeParam, key string, objectField schema.ObjectField, isNullable bool) {
+	sb.builder.WriteString("  j.")
+	sb.builder.WriteString(fieldName)
+	sb.builder.WriteString(", err = utils.")
+	sb.builder.WriteString(functionName)
+	if !isNullable && len(objectField.Type) > 0 {
+		if typeEnum, err := objectField.Type.Type(); err == nil && typeEnum == schema.TypeNullable {
+			sb.builder.WriteString("Default")
+		}
+	}
+	if typeParam != "" {
+		sb.builder.WriteRune('[')
+		sb.builder.WriteString(typeParam)
+		sb.builder.WriteRune(']')
+	}
+	sb.builder.WriteString(`(input, "`)
+	sb.builder.WriteString(key)
+	sb.builder.WriteString(`")`)
 }
 
 func formatLocalFieldName(input string, others ...string) string {

--- a/cmd/hasura-ndc-go/command/internal/constant.go
+++ b/cmd/hasura-ndc-go/command/internal/constant.go
@@ -134,26 +134,13 @@ var defaultScalarTypes = map[ScalarName]schema.ScalarType{
 }
 
 var (
+	fieldNameRegex           = regexp.MustCompile(`[^\w]`)
 	ndcOperationNameRegex    = regexp.MustCompile(`^(Function|Procedure)([A-Z][A-Za-z0-9]*)$`)
 	ndcOperationCommentRegex = regexp.MustCompile(`^@(function|procedure)(\s+([A-Za-z]\w*))?`)
 	ndcScalarNameRegex       = regexp.MustCompile(`^Scalar([A-Z]\w*)$`)
 	ndcScalarCommentRegex    = regexp.MustCompile(`^@scalar(\s+(\w+))?(\s+([a-z]+))?$`)
 	ndcEnumCommentRegex      = regexp.MustCompile(`^@enum\s+([\w-.,!@#$%^&*()+=~\s\t]+)$`)
 )
-
-var fieldNameRegex = regexp.MustCompile(`[^\w]`)
-
-const textBlockErrorCheck = `
-    if err != nil {
-		  return err
-    }
-`
-
-const textBlockErrorCheck2 = `
-    if err != nil {
-      return nil, err
-    }
-`
 
 var (
 	errUnsupportedTypeDuration = errors.New("unsupported type time.Duration. Create a scalar type wrapper with FromValue method to decode the any value")

--- a/cmd/hasura-ndc-go/command/internal/schema_parser.go
+++ b/cmd/hasura-ndc-go/command/internal/schema_parser.go
@@ -14,7 +14,6 @@ import (
 	"runtime/trace"
 	"strings"
 
-	"github.com/fatih/structtag"
 	"github.com/hasura/ndc-sdk-go/schema"
 	"github.com/iancoleman/strcase"
 	"github.com/rs/zerolog/log"
@@ -361,27 +360,6 @@ func findCommentsFromPos(pkg *packages.Package, scope *types.Scope, name string)
 		}
 	}
 	return nil
-}
-
-// get field name by json tag
-// return the struct field name if not exist.
-func getFieldNameOrTag(name string, tag string) string {
-	if tag == "" {
-		return name
-	}
-	tags, err := structtag.Parse(tag)
-	if err != nil {
-		log.Warn().Err(err).Msgf("failed to parse tag of struct field: %s", name)
-		return name
-	}
-
-	jsonTag, err := tags.Get("json")
-	if err != nil {
-		log.Warn().Err(err).Msgf("json tag does not exist in struct field: %s", name)
-		return name
-	}
-
-	return jsonTag.Name
 }
 
 func evalPackageTypesLocation(moduleName string, filePath string, connectorDir string) (string, error) {

--- a/cmd/hasura-ndc-go/command/internal/schema_type_parser.go
+++ b/cmd/hasura-ndc-go/command/internal/schema_type_parser.go
@@ -6,7 +6,9 @@ import (
 	"go/types"
 	"strings"
 
+	"github.com/fatih/structtag"
 	"github.com/hasura/ndc-sdk-go/schema"
+	"github.com/rs/zerolog/log"
 )
 
 type TypeParser struct {
@@ -49,41 +51,8 @@ func (tp *TypeParser) parseArgumentTypes(ty types.Type, fieldPaths []string) (*O
 			Fields:       map[string]Field{},
 			SchemaFields: schema.ObjectTypeFields{},
 		}
-		for i := 0; i < inferredType.NumFields(); i++ {
-			fieldVar := inferredType.Field(i)
-			fieldTag := inferredType.Tag(i)
-			fieldPackage := fieldVar.Pkg()
-
-			fieldParser := NewTypeParser(tp.schemaParser, &Field{
-				Name:     fieldVar.Name(),
-				Embedded: fieldVar.Embedded(),
-			}, fieldVar.Type(), tp.argumentFor)
-
-			if fieldPackage != nil {
-				fieldParser.typeInfo = &TypeInfo{
-					PackageName: fieldPackage.Name(),
-					PackagePath: fieldPackage.Path(),
-				}
-			}
-
-			field, err := fieldParser.Parse(append(fieldPaths, fieldVar.Name()))
-			if err != nil {
-				return nil, err
-			}
-
-			fieldName := getFieldNameOrTag(fieldVar.Name(), fieldTag)
-			result.Fields[fieldName] = *field
-			embeddedObject, ok := tp.schemaParser.rawSchema.Objects[field.Type.SchemaName(false)]
-			if field.Embedded && ok {
-				// flatten embedded object fields to the parent object
-				for k, of := range embeddedObject.SchemaFields {
-					result.SchemaFields[k] = of
-				}
-			} else {
-				result.SchemaFields[fieldName] = schema.ObjectField{
-					Type: field.Type.Schema().Encode(),
-				}
-			}
+		if err := tp.parseStructType(result, inferredType, fieldPaths); err != nil {
+			return nil, err
 		}
 		return result, nil
 	case *types.Named:
@@ -148,31 +117,8 @@ func (tp *TypeParser) parseType(ty types.Type, fieldPaths []string) (Type, error
 		// temporarily add the object type to raw schema to avoid infinite loop
 		tp.schemaParser.rawSchema.Objects[typeInfo.SchemaName] = objFields
 
-		for i := 0; i < inferredType.NumFields(); i++ {
-			fieldVar := inferredType.Field(i)
-			fieldTag := inferredType.Tag(i)
-
-			fieldParser := NewTypeParser(tp.schemaParser, &Field{
-				Name:     fieldVar.Name(),
-				Embedded: fieldVar.Embedded(),
-			}, fieldVar.Type(), tp.argumentFor)
-			field, err := fieldParser.Parse(append(fieldPaths, fieldVar.Name()))
-			if err != nil {
-				return nil, err
-			}
-			fieldKey := getFieldNameOrTag(fieldVar.Name(), fieldTag)
-			embeddedObject, ok := tp.schemaParser.rawSchema.Objects[field.Type.SchemaName(false)]
-			if field.Embedded && ok {
-				// flatten embedded object fields to the parent object
-				for k, of := range embeddedObject.SchemaFields {
-					objFields.SchemaFields[k] = of
-				}
-			} else {
-				objFields.SchemaFields[fieldKey] = schema.ObjectField{
-					Type: field.Type.Schema().Encode(),
-				}
-			}
-			objFields.Fields[fieldKey] = *field
+		if err := tp.parseStructType(&objFields, inferredType, fieldPaths); err != nil {
+			return nil, err
 		}
 		tp.schemaParser.rawSchema.Objects[typeInfo.SchemaName] = objFields
 
@@ -373,6 +319,41 @@ func (tp *TypeParser) parseType(ty types.Type, fieldPaths []string) (Type, error
 	}
 }
 
+func (tp *TypeParser) parseStructType(objectInfo *ObjectInfo, inferredType *types.Struct, fieldPaths []string) error {
+	for i := 0; i < inferredType.NumFields(); i++ {
+		fieldVar := inferredType.Field(i)
+		fieldTag := inferredType.Tag(i)
+
+		fieldParser := NewTypeParser(tp.schemaParser, &Field{
+			Name:     fieldVar.Name(),
+			Embedded: fieldVar.Embedded(),
+		}, fieldVar.Type(), tp.argumentFor)
+		field, err := fieldParser.Parse(append(fieldPaths, fieldVar.Name()))
+		if err != nil {
+			return err
+		}
+		fieldKey, nullable := getFieldNameOrTag(fieldVar.Name(), fieldTag)
+		embeddedObject, ok := tp.schemaParser.rawSchema.Objects[field.Type.SchemaName(false)]
+		if field.Embedded && ok {
+			// flatten embedded object fields to the parent object
+			for k, of := range embeddedObject.SchemaFields {
+				objectInfo.SchemaFields[k] = of
+			}
+		} else {
+			fieldSchema := field.Type.Schema()
+			if nullable && field.Type.Kind() != schema.TypeNullable {
+				fieldSchema = schema.NewNullableType(fieldSchema)
+			}
+			objectInfo.SchemaFields[fieldKey] = schema.ObjectField{
+				Type: fieldSchema.Encode(),
+			}
+		}
+		objectInfo.Fields[fieldKey] = *field
+	}
+
+	return nil
+}
+
 func (tp *TypeParser) parseSliceType(ty types.Type, fieldPaths []string) (Type, error) {
 	innerType, err := tp.parseType(ty, fieldPaths)
 	if err != nil {
@@ -536,4 +517,29 @@ func parseTypeFromString(input string) (Type, error) {
 	typeInfo.Name = parts[partsLen-1]
 
 	return NewNamedType(typeInfo.Name, typeInfo), nil
+}
+
+// get field name by json tag
+// return the struct field name if not exist.
+func getFieldNameOrTag(name string, tag string) (string, bool) {
+	if tag == "" {
+		return name, false
+	}
+	tags, err := structtag.Parse(tag)
+	if err != nil {
+		log.Warn().Err(err).Msgf("failed to parse tag of struct field: %s", name)
+		return name, false
+	}
+
+	jsonTag, err := tags.Get("json")
+	if err != nil {
+		log.Warn().Err(err).Msgf("json tag does not exist in struct field: %s", name)
+		return name, false
+	}
+
+	nameParts := strings.Split(jsonTag.Value(), ",")
+	if len(nameParts) == 1 {
+		return jsonTag.Name, false
+	}
+	return nameParts[0], nameParts[1] == "omitempty"
 }

--- a/cmd/hasura-ndc-go/command/internal/schema_type_parser.go
+++ b/cmd/hasura-ndc-go/command/internal/schema_type_parser.go
@@ -526,8 +526,8 @@ const (
 	jsonIgnore    = "-"
 )
 
-// get field name by json tag
-// return the struct field name if not exist.
+// Get field name and options by json tag.
+// Return the struct field name if not exist.
 func getFieldNameOrTag(name string, tag string) (string, string) {
 	if tag == "" {
 		return name, ""

--- a/cmd/hasura-ndc-go/command/internal/template.go
+++ b/cmd/hasura-ndc-go/command/internal/template.go
@@ -45,3 +45,21 @@ func writeIndent(builder *strings.Builder, num int) {
 		_, _ = builder.WriteRune(' ')
 	}
 }
+
+func writeErrorCheck(sb *strings.Builder, paramCount int, indent int) {
+	sb.WriteRune('\n')
+	writeIndent(sb, indent)
+	sb.WriteString("if err != nil {\n")
+	writeIndent(sb, indent)
+	sb.WriteString("  return ")
+	for i := 0; i < paramCount; i++ {
+		if i == paramCount-1 {
+			sb.WriteString("err")
+		} else {
+			sb.WriteString("nil, ")
+		}
+	}
+	sb.WriteRune('\n')
+	writeIndent(sb, indent)
+	sb.WriteString("}\n")
+}

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/functions.go.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/functions.go.tmpl
@@ -21,611 +21,839 @@ var connector_Decoder = utils.NewDecoder()
 func (j *Author) FromValue(input map[string]any) error {
   var err error
   j.CreatedAt, err = utils.GetDateTime(input, "created_at")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ID, err = utils.GetString(input, "id")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   return nil
 }
 // FromValue decodes values from map
 func (j *BaseAuthor) FromValue(input map[string]any) error {
   var err error
   j.Name, err = utils.GetString(input, "name")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   return nil
 }
 // FromValue decodes values from map
 func (j *GetArticlesArguments) FromValue(input map[string]any) error {
   var err error
   j.Limit, err = utils.GetFloat[float64](input, "Limit")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   return nil
 }
 // FromValue decodes values from map
 func (j *GetTypesArguments) FromValue(input map[string]any) error {
   var err error
   err = connector_Decoder.DecodeObjectValue(&j.ArrayBigInt, input, "ArrayBigInt")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.ArrayBigIntPtr, input, "ArrayBigIntPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayBool, err = utils.GetBooleanSlice(input, "ArrayBool")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayBoolPtr, err = utils.GetBooleanPtrSlice(input, "ArrayBoolPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayFloat32, err = utils.GetFloatSlice[float32](input, "ArrayFloat32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayFloat32Ptr, err = utils.GetFloatPtrSlice[float32](input, "ArrayFloat32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayFloat64, err = utils.GetFloatSlice[float64](input, "ArrayFloat64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayFloat64Ptr, err = utils.GetFloatPtrSlice[float64](input, "ArrayFloat64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt, err = utils.GetIntSlice[int](input, "ArrayInt")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt16, err = utils.GetIntSlice[int16](input, "ArrayInt16")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt16Ptr, err = utils.GetIntPtrSlice[int16](input, "ArrayInt16Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt32, err = utils.GetIntSlice[int32](input, "ArrayInt32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt32Ptr, err = utils.GetIntPtrSlice[int32](input, "ArrayInt32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt64, err = utils.GetIntSlice[int64](input, "ArrayInt64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt64Ptr, err = utils.GetIntPtrSlice[int64](input, "ArrayInt64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt8, err = utils.GetIntSlice[int8](input, "ArrayInt8")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayInt8Ptr, err = utils.GetIntPtrSlice[int8](input, "ArrayInt8Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayIntPtr, err = utils.GetIntPtrSlice[int](input, "ArrayIntPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayJSON, err = utils.GetArbitraryJSONSlice(input, "ArrayJSON")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayJSONPtr, err = utils.GetArbitraryJSONPtrSlice(input, "ArrayJSONPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.ArrayMap, input, "ArrayMap")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayMapPtr = new([]map[string]any)
   err = connector_Decoder.DecodeNullableObjectValue(j.ArrayMapPtr, input, "ArrayMapPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.ArrayObject, input, "ArrayObject")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayObjectPtr = new([]struct{Content string "json:\"content\""})
   err = connector_Decoder.DecodeNullableObjectValue(j.ArrayObjectPtr, input, "ArrayObjectPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayRawJSON, err = utils.GetRawJSONSlice(input, "ArrayRawJSON")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayRawJSONPtr, err = utils.GetRawJSONPtrSlice(input, "ArrayRawJSONPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayString, err = utils.GetStringSlice(input, "ArrayString")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayStringPtr, err = utils.GetStringPtrSlice(input, "ArrayStringPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayTime, err = utils.GetDateTimeSlice(input, "ArrayTime")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayTimePtr, err = utils.GetDateTimePtrSlice(input, "ArrayTimePtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUUID, err = utils.GetUUIDSlice(input, "ArrayUUID")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUUIDPtr, err = utils.GetUUIDPtrSlice(input, "ArrayUUIDPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint, err = utils.GetUintSlice[uint](input, "ArrayUint")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint16, err = utils.GetUintSlice[uint16](input, "ArrayUint16")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint16Ptr, err = utils.GetUintPtrSlice[uint16](input, "ArrayUint16Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint32, err = utils.GetUintSlice[uint32](input, "ArrayUint32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint32Ptr, err = utils.GetUintPtrSlice[uint32](input, "ArrayUint32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint64, err = utils.GetUintSlice[uint64](input, "ArrayUint64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint64Ptr, err = utils.GetUintPtrSlice[uint64](input, "ArrayUint64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint8, err = utils.GetUintSlice[uint8](input, "ArrayUint8")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUint8Ptr, err = utils.GetUintPtrSlice[uint8](input, "ArrayUint8Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ArrayUintPtr, err = utils.GetUintPtrSlice[uint](input, "ArrayUintPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.BigInt, input, "BigInt")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.BigIntPtr = new(scalar.BigInt)
   err = connector_Decoder.DecodeNullableObjectValue(j.BigIntPtr, input, "BigIntPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Bool, err = utils.GetBoolean(input, "Bool")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.BoolPtr, err = utils.GetNullableBoolean(input, "BoolPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.Bytes, input, "Bytes")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.BytesPtr = new(scalar.Bytes)
   err = connector_Decoder.DecodeNullableObjectValue(j.BytesPtr, input, "BytesPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.CustomScalar, input, "CustomScalar")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.CustomScalarPtr = new(CommentText)
   err = connector_Decoder.DecodeNullableObjectValue(j.CustomScalarPtr, input, "CustomScalarPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.Enum, input, "Enum")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.EnumPtr = new(SomeEnum)
   err = connector_Decoder.DecodeNullableObjectValue(j.EnumPtr, input, "EnumPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Float32, err = utils.GetFloat[float32](input, "Float32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Float32Ptr, err = utils.GetNullableFloat[float32](input, "Float32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Float64, err = utils.GetFloat[float64](input, "Float64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Float64Ptr, err = utils.GetNullableFloat[float64](input, "Float64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int, err = utils.GetInt[int](input, "Int")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int16, err = utils.GetInt[int16](input, "Int16")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int16Ptr, err = utils.GetNullableInt[int16](input, "Int16Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int32, err = utils.GetInt[int32](input, "Int32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int32Ptr, err = utils.GetNullableInt[int32](input, "Int32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int64, err = utils.GetInt[int64](input, "Int64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int64Ptr, err = utils.GetNullableInt[int64](input, "Int64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int8, err = utils.GetInt[int8](input, "Int8")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Int8Ptr, err = utils.GetNullableInt[int8](input, "Int8Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.IntPtr, err = utils.GetNullableInt[int](input, "IntPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.JSON, err = utils.GetArbitraryJSON(input, "JSON")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.JSONPtr, err = utils.GetNullableArbitraryJSON(input, "JSONPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.Map, input, "Map")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.MapPtr = new(map[string]any)
   err = connector_Decoder.DecodeNullableObjectValue(j.MapPtr, input, "MapPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.NamedArray, input, "NamedArray")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.NamedArrayPtr = new([]Author)
   err = connector_Decoder.DecodeNullableObjectValue(j.NamedArrayPtr, input, "NamedArrayPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.NamedObject, input, "NamedObject")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.NamedObjectPtr = new(Author)
   err = connector_Decoder.DecodeNullableObjectValue(j.NamedObjectPtr, input, "NamedObjectPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.Object, input, "Object")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.ObjectPtr = new(struct{Long int; Lat int})
   err = connector_Decoder.DecodeNullableObjectValue(j.ObjectPtr, input, "ObjectPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayBigInt = new([]scalar.BigInt)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayBigInt, input, "PtrArrayBigInt")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayBigIntPtr = new([]*scalar.BigInt)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayBigIntPtr, input, "PtrArrayBigIntPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayBool = new([]bool)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayBool, input, "PtrArrayBool")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayBoolPtr, err = utils.GetNullableBooleanPtrSlice(input, "PtrArrayBoolPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayFloat32 = new([]float32)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayFloat32, input, "PtrArrayFloat32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayFloat32Ptr, err = utils.GetNullableFloatPtrSlice[float32](input, "PtrArrayFloat32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayFloat64 = new([]float64)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayFloat64, input, "PtrArrayFloat64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayFloat64Ptr, err = utils.GetNullableFloatPtrSlice[float64](input, "PtrArrayFloat64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt = new([]int)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayInt, input, "PtrArrayInt")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt16 = new([]int16)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayInt16, input, "PtrArrayInt16")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt16Ptr, err = utils.GetNullableIntPtrSlice[int16](input, "PtrArrayInt16Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt32 = new([]int32)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayInt32, input, "PtrArrayInt32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt32Ptr, err = utils.GetNullableIntPtrSlice[int32](input, "PtrArrayInt32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt64 = new([]int64)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayInt64, input, "PtrArrayInt64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt64Ptr, err = utils.GetNullableIntPtrSlice[int64](input, "PtrArrayInt64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt8 = new([]int8)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayInt8, input, "PtrArrayInt8")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayInt8Ptr, err = utils.GetNullableIntPtrSlice[int8](input, "PtrArrayInt8Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayIntPtr, err = utils.GetNullableIntPtrSlice[int](input, "PtrArrayIntPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayJSON = new([]any)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayJSON, input, "PtrArrayJSON")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayJSONPtr, err = utils.GetNullableArbitraryJSONPtrSlice(input, "PtrArrayJSONPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayRawJSON = new([]json.RawMessage)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayRawJSON, input, "PtrArrayRawJSON")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayRawJSONPtr, err = utils.GetNullableRawJSONPtrSlice(input, "PtrArrayRawJSONPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayString = new([]string)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayString, input, "PtrArrayString")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayStringPtr, err = utils.GetNullableStringPtrSlice(input, "PtrArrayStringPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayTime = new([]time.Time)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayTime, input, "PtrArrayTime")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayTimePtr, err = utils.GetNullableDateTimePtrSlice(input, "PtrArrayTimePtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUUID = new([]uuid.UUID)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayUUID, input, "PtrArrayUUID")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUUIDPtr, err = utils.GetNullableUUIDPtrSlice(input, "PtrArrayUUIDPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint = new([]uint)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayUint, input, "PtrArrayUint")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint16 = new([]uint16)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayUint16, input, "PtrArrayUint16")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint16Ptr, err = utils.GetNullableUintPtrSlice[uint16](input, "PtrArrayUint16Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint32 = new([]uint32)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayUint32, input, "PtrArrayUint32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint32Ptr, err = utils.GetNullableUintPtrSlice[uint32](input, "PtrArrayUint32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint64 = new([]uint64)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayUint64, input, "PtrArrayUint64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint64Ptr, err = utils.GetNullableUintPtrSlice[uint64](input, "PtrArrayUint64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint8 = new([]uint8)
   err = connector_Decoder.DecodeNullableObjectValue(j.PtrArrayUint8, input, "PtrArrayUint8")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUint8Ptr, err = utils.GetNullableUintPtrSlice[uint8](input, "PtrArrayUint8Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.PtrArrayUintPtr, err = utils.GetNullableUintPtrSlice[uint](input, "PtrArrayUintPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.RawJSON, err = utils.GetRawJSON(input, "RawJSON")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.RawJSONPtr, err = utils.GetNullableRawJSON(input, "RawJSONPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.String, err = utils.GetString(input, "String")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.StringPtr, err = utils.GetNullableString(input, "StringPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.Text, input, "Text")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.TextPtr = new(Text)
   err = connector_Decoder.DecodeNullableObjectValue(j.TextPtr, input, "TextPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Time, err = utils.GetDateTime(input, "Time")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.TimePtr, err = utils.GetNullableDateTime(input, "TimePtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   err = connector_Decoder.DecodeObjectValue(&j.URL, input, "URL")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.UUID, err = utils.GetUUID(input, "UUID")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.UUIDArray, err = utils.GetUUIDSlice(input, "UUIDArray")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.UUIDPtr, err = utils.GetNullableUUID(input, "UUIDPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint, err = utils.GetUint[uint](input, "Uint")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint16, err = utils.GetUint[uint16](input, "Uint16")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint16Ptr, err = utils.GetNullableUint[uint16](input, "Uint16Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint32, err = utils.GetUint[uint32](input, "Uint32")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint32Ptr, err = utils.GetNullableUint[uint32](input, "Uint32Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint64, err = utils.GetUint[uint64](input, "Uint64")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint64Ptr, err = utils.GetNullableUint[uint64](input, "Uint64Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint8, err = utils.GetUint[uint8](input, "Uint8")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.Uint8Ptr, err = utils.GetNullableUint[uint8](input, "Uint8Ptr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
   j.UintPtr, err = utils.GetNullableUint[uint](input, "UintPtr")
-    if err != nil {
-		  return err
-    }
+  if err != nil {
+    return err
+  }
+  err = connector_Decoder.DecodeNullableObjectValue(&j.ArrayBigIntEmpty, input, "array_bigint_empty")
+  if err != nil {
+    return err
+  }
+  err = connector_Decoder.DecodeNullableObjectValue(&j.ArrayBigIntPtrEmpty, input, "array_bigint_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayBoolEmpty, err = utils.GetBooleanSliceDefault(input, "array_bool_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayBoolPtrEmpty, err = utils.GetBooleanPtrSliceDefault(input, "array_bool_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayFloat32Empty, err = utils.GetFloatSliceDefault[float32](input, "array_float32_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayFloat32PtrEmpty, err = utils.GetFloatPtrSliceDefault[float32](input, "array_float32_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayFloat64Empty, err = utils.GetFloatSliceDefault[float64](input, "array_float64_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayFloat64PtrEmpty, err = utils.GetFloatPtrSliceDefault[float64](input, "array_float64_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt16Empty, err = utils.GetIntSliceDefault[int16](input, "array_int16_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt16PtrEmpty, err = utils.GetIntPtrSliceDefault[int16](input, "array_int16_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt32Empty, err = utils.GetIntSliceDefault[int32](input, "array_int32_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt32PtrEmpty, err = utils.GetIntPtrSliceDefault[int32](input, "array_int32_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt64Empty, err = utils.GetIntSliceDefault[int64](input, "array_int64_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt64PtrEmpty, err = utils.GetIntPtrSliceDefault[int64](input, "array_int64_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt8Empty, err = utils.GetIntSliceDefault[int8](input, "array_int8_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayInt8PtrEmpty, err = utils.GetIntPtrSliceDefault[int8](input, "array_int8_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayIntEmpty, err = utils.GetIntSliceDefault[int](input, "array_int_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayIntPtrEmpty, err = utils.GetIntPtrSliceDefault[int](input, "array_int_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayJSONEmpty, err = utils.GetArbitraryJSONSliceDefault(input, "array_json_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayJSONPtrEmpty, err = utils.GetArbitraryJSONPtrSliceDefault(input, "array_json_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayRawJSONEmpty, err = utils.GetRawJSONSliceDefault(input, "array_raw_json_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayRawJSONPtrEmpty, err = utils.GetRawJSONPtrSliceDefault(input, "array_raw_json_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayStringEmpty, err = utils.GetStringSliceDefault(input, "array_string_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayStringPtrEmpty, err = utils.GetStringPtrSliceDefault(input, "array_string_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayTimeEmpty, err = utils.GetDateTimeSliceDefault(input, "array_time_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayTimePtrEmpty, err = utils.GetDateTimePtrSliceDefault(input, "array_time_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint16Empty, err = utils.GetUintSliceDefault[uint16](input, "array_uint16_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint16PtrEmpty, err = utils.GetUintPtrSliceDefault[uint16](input, "array_uint16_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint32Empty, err = utils.GetUintSliceDefault[uint32](input, "array_uint32_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint32PtrEmpty, err = utils.GetUintPtrSliceDefault[uint32](input, "array_uint32_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint64Empty, err = utils.GetUintSliceDefault[uint64](input, "array_uint64_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint64PtrEmpty, err = utils.GetUintPtrSliceDefault[uint64](input, "array_uint64_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint8Empty, err = utils.GetUintSliceDefault[uint8](input, "array_uint8_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUint8PtrEmpty, err = utils.GetUintPtrSliceDefault[uint8](input, "array_uint8_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUintEmpty, err = utils.GetUintSliceDefault[uint](input, "array_uint_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUintPtrEmpty, err = utils.GetUintPtrSliceDefault[uint](input, "array_uint_ptr_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUUIDEmpty, err = utils.GetUUIDSliceDefault(input, "array_uuid_empty")
+  if err != nil {
+    return err
+  }
+  j.ArrayUUIDPtrEmpty, err = utils.GetUUIDPtrSliceDefault(input, "array_uuid_ptr_empty")
+  if err != nil {
+    return err
+  }
+  err = connector_Decoder.DecodeNullableObjectValue(&j.BigIntEmpty, input, "bigint_empty")
+  if err != nil {
+    return err
+  }
+  j.BoolEmpty, err = utils.GetBooleanDefault(input, "bool_empty")
+  if err != nil {
+    return err
+  }
+  err = connector_Decoder.DecodeNullableObjectValue(&j.DateEmpty, input, "date_empty")
+  if err != nil {
+    return err
+  }
+  j.Float32Empty, err = utils.GetFloatDefault[float32](input, "float32_empty")
+  if err != nil {
+    return err
+  }
+  j.Float64Empty, err = utils.GetFloatDefault[float64](input, "float64_empty")
+  if err != nil {
+    return err
+  }
+  j.Int16Empty, err = utils.GetIntDefault[int16](input, "int16_empty")
+  if err != nil {
+    return err
+  }
+  j.Int32Empty, err = utils.GetIntDefault[int32](input, "int32_empty")
+  if err != nil {
+    return err
+  }
+  j.Int64Empty, err = utils.GetIntDefault[int64](input, "int64_empty")
+  if err != nil {
+    return err
+  }
+  j.Int8Empty, err = utils.GetIntDefault[int8](input, "int8_empty")
+  if err != nil {
+    return err
+  }
+  j.IntEmpty, err = utils.GetIntDefault[int](input, "int_empty")
+  if err != nil {
+    return err
+  }
+  j.StringEmpty, err = utils.GetStringDefault(input, "string_empty")
+  if err != nil {
+    return err
+  }
+  j.TimeEmpty, err = utils.GetDateTimeDefault(input, "time_empty")
+  if err != nil {
+    return err
+  }
+  j.Uint16Empty, err = utils.GetUintDefault[uint16](input, "uint16_empty")
+  if err != nil {
+    return err
+  }
+  j.Uint32Empty, err = utils.GetUintDefault[uint32](input, "uint32_empty")
+  if err != nil {
+    return err
+  }
+  j.Uint64Empty, err = utils.GetUintDefault[uint64](input, "uint64_empty")
+  if err != nil {
+    return err
+  }
+  j.Uint8Empty, err = utils.GetUintDefault[uint8](input, "uint8_empty")
+  if err != nil {
+    return err
+  }
+  j.UintEmpty, err = utils.GetUintDefault[uint](input, "uint_empty")
+  if err != nil {
+    return err
+  }
+  err = connector_Decoder.DecodeNullableObjectValue(&j.URLEmpty, input, "url_empty")
+  if err != nil {
+    return err
+  }
+  j.UUIDEmpty, err = utils.GetUUIDDefault(input, "uuid_empty")
+  if err != nil {
+    return err
+  }
   return nil
 }
 // ToMap encodes the struct to a value map
@@ -634,14 +862,14 @@ func (j Author) ToMap() map[string]any {
   r["created_at"] = j.CreatedAt
   r["id"] = j.ID
 
-	return r
+  return r
 }
 // ToMap encodes the struct to a value map
 func (j BaseAuthor) ToMap() map[string]any {
   r := make(map[string]any)
   r["name"] = j.Name
 
-	return r
+  return r
 }
 // ToMap encodes the struct to a value map
 func (j CreateArticleResult) ToMap() map[string]any {
@@ -653,7 +881,7 @@ func (j CreateArticleResult) ToMap() map[string]any {
   r["authors"] = j_Authors
   r["id"] = j.ID
 
-	return r
+  return r
 }
 // ToMap encodes the struct to a value map
 func (j CreateAuthorResult) ToMap() map[string]any {
@@ -662,7 +890,7 @@ func (j CreateAuthorResult) ToMap() map[string]any {
   r["id"] = j.ID
   r["name"] = j.Name
 
-	return r
+  return r
 }
 // ToMap encodes the struct to a value map
 func (j GetArticlesResult) ToMap() map[string]any {
@@ -670,7 +898,7 @@ func (j GetArticlesResult) ToMap() map[string]any {
   r["Name"] = j.Name
   r["id"] = j.ID
 
-	return r
+  return r
 }
 // ToMap encodes the struct to a value map
 func (j GetTypesArguments) ToMap() map[string]any {
@@ -845,8 +1073,65 @@ func (j GetTypesArguments) ToMap() map[string]any {
   r["Uint8"] = j.Uint8
   r["Uint8Ptr"] = j.Uint8Ptr
   r["UintPtr"] = j.UintPtr
+  r["array_bigint_empty"] = j.ArrayBigIntEmpty
+  r["array_bigint_ptr_empty"] = j.ArrayBigIntPtrEmpty
+  r["array_bool_empty"] = j.ArrayBoolEmpty
+  r["array_bool_ptr_empty"] = j.ArrayBoolPtrEmpty
+  r["array_float32_empty"] = j.ArrayFloat32Empty
+  r["array_float32_ptr_empty"] = j.ArrayFloat32PtrEmpty
+  r["array_float64_empty"] = j.ArrayFloat64Empty
+  r["array_float64_ptr_empty"] = j.ArrayFloat64PtrEmpty
+  r["array_int16_empty"] = j.ArrayInt16Empty
+  r["array_int16_ptr_empty"] = j.ArrayInt16PtrEmpty
+  r["array_int32_empty"] = j.ArrayInt32Empty
+  r["array_int32_ptr_empty"] = j.ArrayInt32PtrEmpty
+  r["array_int64_empty"] = j.ArrayInt64Empty
+  r["array_int64_ptr_empty"] = j.ArrayInt64PtrEmpty
+  r["array_int8_empty"] = j.ArrayInt8Empty
+  r["array_int8_ptr_empty"] = j.ArrayInt8PtrEmpty
+  r["array_int_empty"] = j.ArrayIntEmpty
+  r["array_int_ptr_empty"] = j.ArrayIntPtrEmpty
+  r["array_json_empty"] = j.ArrayJSONEmpty
+  r["array_json_ptr_empty"] = j.ArrayJSONPtrEmpty
+  r["array_raw_json_empty"] = j.ArrayRawJSONEmpty
+  r["array_raw_json_ptr_empty"] = j.ArrayRawJSONPtrEmpty
+  r["array_string_empty"] = j.ArrayStringEmpty
+  r["array_string_ptr_empty"] = j.ArrayStringPtrEmpty
+  r["array_time_empty"] = j.ArrayTimeEmpty
+  r["array_time_ptr_empty"] = j.ArrayTimePtrEmpty
+  r["array_uint16_empty"] = j.ArrayUint16Empty
+  r["array_uint16_ptr_empty"] = j.ArrayUint16PtrEmpty
+  r["array_uint32_empty"] = j.ArrayUint32Empty
+  r["array_uint32_ptr_empty"] = j.ArrayUint32PtrEmpty
+  r["array_uint64_empty"] = j.ArrayUint64Empty
+  r["array_uint64_ptr_empty"] = j.ArrayUint64PtrEmpty
+  r["array_uint8_empty"] = j.ArrayUint8Empty
+  r["array_uint8_ptr_empty"] = j.ArrayUint8PtrEmpty
+  r["array_uint_empty"] = j.ArrayUintEmpty
+  r["array_uint_ptr_empty"] = j.ArrayUintPtrEmpty
+  r["array_uuid_empty"] = j.ArrayUUIDEmpty
+  r["array_uuid_ptr_empty"] = j.ArrayUUIDPtrEmpty
+  r["bigint_empty"] = j.BigIntEmpty
+  r["bool_empty"] = j.BoolEmpty
+  r["date_empty"] = j.DateEmpty
+  r["float32_empty"] = j.Float32Empty
+  r["float64_empty"] = j.Float64Empty
+  r["int16_empty"] = j.Int16Empty
+  r["int32_empty"] = j.Int32Empty
+  r["int64_empty"] = j.Int64Empty
+  r["int8_empty"] = j.Int8Empty
+  r["int_empty"] = j.IntEmpty
+  r["string_empty"] = j.StringEmpty
+  r["time_empty"] = j.TimeEmpty
+  r["uint16_empty"] = j.Uint16Empty
+  r["uint32_empty"] = j.Uint32Empty
+  r["uint64_empty"] = j.Uint64Empty
+  r["uint8_empty"] = j.Uint8Empty
+  r["uint_empty"] = j.UintEmpty
+  r["url_empty"] = j.URLEmpty
+  r["uuid_empty"] = j.UUIDEmpty
 
-	return r
+  return r
 }
 // ToMap encodes the struct to a value map
 func (j HelloResult) ToMap() map[string]any {
@@ -857,7 +1142,7 @@ func (j HelloResult) ToMap() map[string]any {
   r["num"] = j.Num
   r["text"] = j.Text
 
-	return r
+  return r
 }
 // ScalarName get the schema name of the scalar
 func (j CommentText) ScalarName() string {
@@ -882,51 +1167,51 @@ var enumValues_SomeEnum = []SomeEnum{SomeEnumFoo, SomeEnumBar}
 
 // ParseSomeEnum parses a SomeEnum enum from string
 func ParseSomeEnum(input string) (SomeEnum, error) {
-	result := SomeEnum(input)
-	if !slices.Contains(enumValues_SomeEnum, result) {
-		return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of SomeEnumFoo, SomeEnumBar")
-	}
+  result := SomeEnum(input)
+  if !slices.Contains(enumValues_SomeEnum, result) {
+    return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of SomeEnumFoo, SomeEnumBar")
+  }
 
-	return result, nil
+  return result, nil
 }
 
 // IsValid checks if the value is invalid
 func (j SomeEnum) IsValid() bool {
-	return slices.Contains(enumValues_SomeEnum, j)
+  return slices.Contains(enumValues_SomeEnum, j)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (j *SomeEnum) UnmarshalJSON(b []byte) error {
-	var rawValue string
-	if err := json.Unmarshal(b, &rawValue); err != nil {
-		return err
-	}
+  var rawValue string
+  if err := json.Unmarshal(b, &rawValue); err != nil {
+    return err
+  }
 
-	value, err := ParseSomeEnum(rawValue)
-	if err != nil {
-		return err
-	}
+  value, err := ParseSomeEnum(rawValue)
+  if err != nil {
+    return err
+  }
 
-	*j = value
-	return nil
+  *j = value
+  return nil
 }
 
 // FromValue decodes the scalar from an unknown value
 func (s *SomeEnum) FromValue(value any) error {
-	valueStr, err := utils.DecodeNullableString(value)
-	if err != nil {
-		return err
-	}
-	if valueStr == nil {
-		return nil
-	}
-	result, err := ParseSomeEnum(*valueStr)
-	if err != nil {
-		return err
-	}
+  valueStr, err := utils.DecodeNullableString(value)
+  if err != nil {
+    return err
+  }
+  if valueStr == nil {
+    return nil
+  }
+  result, err := ParseSomeEnum(*valueStr)
+  if err != nil {
+    return err
+  }
 
-	*s = result
-	return nil
+  *s = result
+  return nil
 }
 
 // DataConnectorHandler implements the data connector handler 
@@ -934,69 +1219,70 @@ type DataConnectorHandler struct{}
 
 // QueryExists check if the query name exists
 func (dch DataConnectorHandler) QueryExists(name string) bool {
-	return slices.Contains(enumValues_FunctionName, name)
+  return slices.Contains(enumValues_FunctionName, name)
 }
 func (dch DataConnectorHandler) Query(ctx context.Context, state *types.State, request *schema.QueryRequest, rawArgs map[string]any) (*schema.RowSet, error) {
-	if !dch.QueryExists(request.Collection) {
-		return nil, utils.ErrHandlerNotfound
-	}
-	queryFields, err := utils.EvalFunctionSelectionFieldValue(request)
-	if err != nil {
-		return nil, schema.UnprocessableContentError(err.Error(), nil)
-	}
+  if !dch.QueryExists(request.Collection) {
+    return nil, utils.ErrHandlerNotfound
+  }
+  queryFields, err := utils.EvalFunctionSelectionFieldValue(request)
+  if err != nil {
+    return nil, schema.UnprocessableContentError(err.Error(), nil)
+  }
 
-	result, err := dch.execQuery(ctx, state, request, queryFields, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	
-	return &schema.RowSet{
-		Aggregates: schema.RowSetAggregates{},
-		Rows: []map[string]any{
-			{
-				"__value": result,
-			},
-		},
-	}, nil
+  result, err := dch.execQuery(ctx, state, request, queryFields, rawArgs)
+  if err != nil {
+    return nil, err
+  }
+  
+  return &schema.RowSet{
+    Aggregates: schema.RowSetAggregates{},
+    Rows: []map[string]any{
+      {
+        "__value": result,
+      },
+    },
+  }, nil
 }
-	
+  
 func (dch DataConnectorHandler) execQuery(ctx context.Context, state *types.State, request *schema.QueryRequest, queryFields schema.NestedField, rawArgs map[string]any) (any, error) {
-	span := trace.SpanFromContext(ctx)
-	logger := connector.GetLogger(ctx)
-	switch request.Collection {
+  span := trace.SpanFromContext(ctx)
+  logger := connector.GetLogger(ctx)
+  switch request.Collection {
   case "getBool":
 
-		if len(queryFields) > 0 {
-			return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
-		}
+      if len(queryFields) > 0 {
+          return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
+        }
     return FunctionGetBool(ctx, state)
 
   case "getCustomHeaders":
 
-		selection, err := queryFields.AsObject()
-		if err != nil {
-			return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
-				"cause": err.Error(),
-			})
-		}
-		var args GetCustomHeadersArguments[BaseAuthor, int]
+    selection, err := queryFields.AsObject()
+    if err != nil {
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
+        "cause": err.Error(),
+      })
+    }
+    var args GetCustomHeadersArguments[BaseAuthor, int]
     if parseErr := connector_Decoder.DecodeObject(&args, rawArgs); parseErr != nil {
-			return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
-				"cause": parseErr.Error(),
-			})
-		}
-		
-		connector_addSpanEvent(span, logger, "execute_function", map[string]any{
-			"arguments": args,
-		})
+      return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
+        "cause": parseErr.Error(),
+      })
+    }
+    
+    connector_addSpanEvent(span, logger, "execute_function", map[string]any{
+      "arguments": args,
+    })
     rawResult, err := FunctionGetCustomHeaders(ctx, state, &args)
+
     if err != nil {
       return nil, err
     }
 
-		connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
-			"raw_result": rawResult,
-		})
+    connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
+      "raw_result": rawResult,
+    })
     result, err := utils.EvalNestedColumnObject(selection, rawResult)
     if err != nil {
       return nil, err
@@ -1005,23 +1291,24 @@ func (dch DataConnectorHandler) execQuery(ctx context.Context, state *types.Stat
 
   case "getTypes":
 
-		selection, err := queryFields.AsObject()
-		if err != nil {
-			return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
-				"cause": err.Error(),
-			})
-		}
-		var args GetTypesArguments
+    selection, err := queryFields.AsObject()
+    if err != nil {
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
+        "cause": err.Error(),
+      })
+    }
+    var args GetTypesArguments
     if parseErr := args.FromValue(rawArgs); parseErr != nil {
-			return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
-				"cause": parseErr.Error(),
-			})
-		}
-		
-		connector_addSpanEvent(span, logger, "execute_function", map[string]any{
-			"arguments": args,
-		})
+      return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
+        "cause": parseErr.Error(),
+      })
+    }
+    
+    connector_addSpanEvent(span, logger, "execute_function", map[string]any{
+      "arguments": args,
+    })
     rawResult, err := FunctionGetTypes(ctx, state, &args)
+
     if err != nil {
       return nil, err
     }
@@ -1029,10 +1316,9 @@ func (dch DataConnectorHandler) execQuery(ctx context.Context, state *types.Stat
     if rawResult == nil {
       return nil, nil
     }
-
-		connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
-			"raw_result": rawResult,
-		})
+    connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
+      "raw_result": rawResult,
+    })
     result, err := utils.EvalNestedColumnObject(selection, rawResult)
     if err != nil {
       return nil, err
@@ -1041,13 +1327,14 @@ func (dch DataConnectorHandler) execQuery(ctx context.Context, state *types.Stat
 
   case "hello":
 
-		selection, err := queryFields.AsObject()
-		if err != nil {
-			return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
-				"cause": err.Error(),
-			})
-		}
+    selection, err := queryFields.AsObject()
+    if err != nil {
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
+        "cause": err.Error(),
+      })
+    }
     rawResult, err := FunctionHello(ctx, state)
+
     if err != nil {
       return nil, err
     }
@@ -1055,10 +1342,9 @@ func (dch DataConnectorHandler) execQuery(ctx context.Context, state *types.Stat
     if rawResult == nil {
       return nil, nil
     }
-
-		connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
-			"raw_result": rawResult,
-		})
+    connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
+      "raw_result": rawResult,
+    })
     result, err := utils.EvalNestedColumnObject(selection, rawResult)
     if err != nil {
       return nil, err
@@ -1067,53 +1353,54 @@ func (dch DataConnectorHandler) execQuery(ctx context.Context, state *types.Stat
 
   case "getArticles":
 
-		selection, err := queryFields.AsArray()
-		if err != nil {
-			return nil, schema.UnprocessableContentError("the selection field type must be array", map[string]any{
-				"cause": err.Error(),
-			})
-		}
-		var args GetArticlesArguments
+    selection, err := queryFields.AsArray()
+    if err != nil {
+      return nil, schema.UnprocessableContentError("the selection field type must be array", map[string]any{
+        "cause": err.Error(),
+      })
+    }
+    var args GetArticlesArguments
     if parseErr := args.FromValue(rawArgs); parseErr != nil {
-			return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
-				"cause": parseErr.Error(),
-			})
-		}
-		
-		connector_addSpanEvent(span, logger, "execute_function", map[string]any{
-			"arguments": args,
-		})
+      return nil, schema.UnprocessableContentError("failed to resolve arguments", map[string]any{
+        "cause": parseErr.Error(),
+      })
+    }
+    
+    connector_addSpanEvent(span, logger, "execute_function", map[string]any{
+      "arguments": args,
+    })
     rawResult, err := GetArticles(ctx, state, &args)
+
     if err != nil {
       return nil, err
     }
 
-		connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
-			"raw_result": rawResult,
-		})
+    connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
+      "raw_result": rawResult,
+    })
     result, err := utils.EvalNestedColumnArrayIntoSlice(selection, rawResult)
     if err != nil {
       return nil, err
     }
     return result, nil
 
-	default:
-		return nil, utils.ErrHandlerNotfound
-	}
+  default:
+    return nil, utils.ErrHandlerNotfound
+  }
 }
 var enumValues_FunctionName = []string{"getBool", "getCustomHeaders", "getTypes", "hello", "getArticles"}
 // MutationExists check if the mutation name exists
 func (dch DataConnectorHandler) MutationExists(name string) bool {
-	return slices.Contains(enumValues_ProcedureName, name)
+  return slices.Contains(enumValues_ProcedureName, name)
 }
 func (dch DataConnectorHandler) Mutation(ctx context.Context, state *types.State, operation *schema.MutationOperation) (schema.MutationOperationResults, error) {
-	span := trace.SpanFromContext(ctx)	
-	logger := connector.GetLogger(ctx)
-	connector_addSpanEvent(span, logger, "validate_request", map[string]any{
-		"operations_name": operation.Name,
-	})
-	
-	switch operation.Name {
+  span := trace.SpanFromContext(ctx)  
+  logger := connector.GetLogger(ctx)
+  connector_addSpanEvent(span, logger, "validate_request", map[string]any{
+    "operations_name": operation.Name,
+  })
+  
+  switch operation.Name {
   case "create_article":
 
     selection, err := operation.Fields.AsObject()
@@ -1139,8 +1426,8 @@ func (dch DataConnectorHandler) Mutation(ctx context.Context, state *types.State
       return schema.NewProcedureResult(nil).Encode(), nil
     }
     connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
-			"raw_result": rawResult,
-		})
+      "raw_result": rawResult,
+    })
     result, err := utils.EvalNestedColumnObject(selection, rawResult)
 
     if err != nil {
@@ -1150,11 +1437,12 @@ func (dch DataConnectorHandler) Mutation(ctx context.Context, state *types.State
 
   case "increase":
 
-    if len(operation.Fields) > 0 {
-      return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
-    }
+      if len(operation.Fields) > 0 {
+          return nil, schema.UnprocessableContentError("cannot evaluate selection fields for scalar", nil)
+        }
     span.AddEvent("execute_procedure")
     result, err := Increase(ctx, state)
+
     if err != nil {
       return nil, err
     }
@@ -1185,8 +1473,8 @@ func (dch DataConnectorHandler) Mutation(ctx context.Context, state *types.State
       return schema.NewProcedureResult(nil).Encode(), nil
     }
     connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
-			"raw_result": rawResult,
-		})
+      "raw_result": rawResult,
+    })
     result, err := utils.EvalNestedColumnObject(selection, rawResult)
 
     if err != nil {
@@ -1214,9 +1502,10 @@ func (dch DataConnectorHandler) Mutation(ctx context.Context, state *types.State
     if err != nil {
       return nil, err
     }
+
     connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
-			"raw_result": rawResult,
-		})
+      "raw_result": rawResult,
+    })
     result, err := utils.EvalNestedColumnArrayIntoSlice(selection, rawResult)
 
     if err != nil {
@@ -1224,13 +1513,47 @@ func (dch DataConnectorHandler) Mutation(ctx context.Context, state *types.State
     }
     return schema.NewProcedureResult(result).Encode(), nil
 
-	default:
-		return nil, utils.ErrHandlerNotfound
-	}
+  case "doCustomHeaders":
+
+    selection, err := operation.Fields.AsObject()
+    if err != nil {
+      return nil, schema.UnprocessableContentError("the selection field type must be object", map[string]any{
+        "cause": err.Error(),
+      })
+    }
+    var args GetCustomHeadersArguments[*[]BaseAuthor, int]
+    if err := json.Unmarshal(operation.Arguments, &args); err != nil {
+      return nil, schema.UnprocessableContentError("failed to decode arguments", map[string]any{
+        "cause": err.Error(),
+      })
+    }
+    span.AddEvent("execute_procedure")
+    rawResult, err := ProcedureDoCustomHeaders(ctx, state, &args)
+
+    if err != nil {
+      return nil, err
+    }
+
+    if rawResult == nil {
+      return schema.NewProcedureResult(nil).Encode(), nil
+    }
+    connector_addSpanEvent(span, logger, "evaluate_response_selection", map[string]any{
+      "raw_result": rawResult,
+    })
+    result, err := utils.EvalNestedColumnObject(selection, rawResult)
+
+    if err != nil {
+      return nil, err
+    }
+    return schema.NewProcedureResult(result).Encode(), nil
+
+  default:
+    return nil, utils.ErrHandlerNotfound
+  }
 }
-var enumValues_ProcedureName = []string{"create_article", "increase", "createAuthor", "createAuthors"}		
+var enumValues_ProcedureName = []string{"create_article", "increase", "createAuthor", "createAuthors", "doCustomHeaders"}    
 func connector_addSpanEvent(span trace.Span, logger *slog.Logger, name string, data map[string]any, options ...trace.EventOption) {
-	logger.Debug(name, slog.Any("data", data))
-	attrs := utils.DebugJSONAttributes(data, utils.IsDebug(logger))
-	span.AddEvent(name, append(options, trace.WithAttributes(attrs...))...)
+  logger.Debug(name, slog.Any("data", data))
+  attrs := utils.DebugJSONAttributes(data, utils.IsDebug(logger))
+  span.AddEvent(name, append(options, trace.WithAttributes(attrs...))...)
 }

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.go.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.go.tmpl
@@ -65,6 +65,16 @@ func GetConnectorSchema() *schema.SchemaResponse {
           },
         },
       },
+      "CustomHeadersResult_array_nullable_BaseAuthor": schema.ObjectType{
+        Fields: schema.ObjectTypeFields{
+          "Response": schema.ObjectField{
+            Type: schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("BaseAuthor"))).Encode(),
+          },
+          "headers": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("JSON")).Encode(),
+          },
+        },
+      },
       "GetArticlesResult": schema.ObjectType{
         Fields: schema.ObjectTypeFields{
           "Name": schema.ObjectField{
@@ -511,6 +521,177 @@ func GetConnectorSchema() *schema.SchemaResponse {
           },
           "UintPtr": schema.ObjectField{
             Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "array_bigint_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("BigInt"))).Encode(),
+          },
+          "array_bigint_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("BigInt")))).Encode(),
+          },
+          "array_bool_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Boolean"))).Encode(),
+          },
+          "array_bool_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Boolean")))).Encode(),
+          },
+          "array_float32_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float32"))).Encode(),
+          },
+          "array_float32_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float32")))).Encode(),
+          },
+          "array_float64_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float64"))).Encode(),
+          },
+          "array_float64_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float64")))).Encode(),
+          },
+          "array_int16_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+          },
+          "array_int16_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+          },
+          "array_int32_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_int32_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_int64_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+          },
+          "array_int64_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+          },
+          "array_int8_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+          },
+          "array_int8_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+          },
+          "array_int_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_int_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_json_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("JSON"))).Encode(),
+          },
+          "array_json_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("JSON")))).Encode(),
+          },
+          "array_raw_json_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("RawJSON"))).Encode(),
+          },
+          "array_raw_json_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("RawJSON")))).Encode(),
+          },
+          "array_string_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("String"))).Encode(),
+          },
+          "array_string_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("String")))).Encode(),
+          },
+          "array_time_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("TimestampTZ"))).Encode(),
+          },
+          "array_time_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("TimestampTZ")))).Encode(),
+          },
+          "array_uint16_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+          },
+          "array_uint16_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+          },
+          "array_uint32_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_uint32_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_uint64_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+          },
+          "array_uint64_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+          },
+          "array_uint8_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+          },
+          "array_uint8_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+          },
+          "array_uint_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_uint_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_uuid_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("UUID"))).Encode(),
+          },
+          "array_uuid_ptr_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("UUID")))).Encode(),
+          },
+          "bigint_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("BigInt")).Encode(),
+          },
+          "bool_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Boolean")).Encode(),
+          },
+          "date_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Date")).Encode(),
+          },
+          "float32_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Float32")).Encode(),
+          },
+          "float64_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Float64")).Encode(),
+          },
+          "int16_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+          },
+          "int32_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "int64_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+          },
+          "int8_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+          },
+          "int_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "string_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),
+          },
+          "time_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("TimestampTZ")).Encode(),
+          },
+          "uint16_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+          },
+          "uint32_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "uint64_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+          },
+          "uint8_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+          },
+          "uint_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "url_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("URL")).Encode(),
+          },
+          "uuid_empty": schema.ObjectField{
+            Type: schema.NewNullableType(schema.NewNamedType("UUID")).Encode(),
           },
         },
       },
@@ -1003,6 +1184,177 @@ func GetConnectorSchema() *schema.SchemaResponse {
           "UintPtr": {
             Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
           },
+          "array_bigint_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("BigInt"))).Encode(),
+          },
+          "array_bigint_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("BigInt")))).Encode(),
+          },
+          "array_bool_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Boolean"))).Encode(),
+          },
+          "array_bool_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Boolean")))).Encode(),
+          },
+          "array_float32_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float32"))).Encode(),
+          },
+          "array_float32_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float32")))).Encode(),
+          },
+          "array_float64_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float64"))).Encode(),
+          },
+          "array_float64_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float64")))).Encode(),
+          },
+          "array_int16_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+          },
+          "array_int16_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+          },
+          "array_int32_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_int32_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_int64_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+          },
+          "array_int64_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+          },
+          "array_int8_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+          },
+          "array_int8_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+          },
+          "array_int_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_int_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_json_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("JSON"))).Encode(),
+          },
+          "array_json_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("JSON")))).Encode(),
+          },
+          "array_raw_json_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("RawJSON"))).Encode(),
+          },
+          "array_raw_json_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("RawJSON")))).Encode(),
+          },
+          "array_string_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("String"))).Encode(),
+          },
+          "array_string_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("String")))).Encode(),
+          },
+          "array_time_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("TimestampTZ"))).Encode(),
+          },
+          "array_time_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("TimestampTZ")))).Encode(),
+          },
+          "array_uint16_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+          },
+          "array_uint16_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+          },
+          "array_uint32_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_uint32_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_uint64_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+          },
+          "array_uint64_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+          },
+          "array_uint8_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+          },
+          "array_uint8_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+          },
+          "array_uint_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+          },
+          "array_uint_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+          },
+          "array_uuid_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("UUID"))).Encode(),
+          },
+          "array_uuid_ptr_empty": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("UUID")))).Encode(),
+          },
+          "bigint_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("BigInt")).Encode(),
+          },
+          "bool_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Boolean")).Encode(),
+          },
+          "date_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Date")).Encode(),
+          },
+          "float32_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Float32")).Encode(),
+          },
+          "float64_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Float64")).Encode(),
+          },
+          "int16_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+          },
+          "int32_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "int64_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+          },
+          "int8_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+          },
+          "int_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "string_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),
+          },
+          "time_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("TimestampTZ")).Encode(),
+          },
+          "uint16_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+          },
+          "uint32_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "uint64_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+          },
+          "uint8_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+          },
+          "uint_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+          },
+          "url_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("URL")).Encode(),
+          },
+          "uuid_empty": {
+            Type: schema.NewNullableType(schema.NewNamedType("UUID")).Encode(),
+          },
         },
       },
 			{
@@ -1061,6 +1413,21 @@ func GetConnectorSchema() *schema.SchemaResponse {
           },
         },
       },
+			{
+				Name: "doCustomHeaders",
+        ResultType: schema.NewNullableType(schema.NewNamedType("CustomHeadersResult_array_nullable_BaseAuthor")).Encode(),
+        Arguments: map[string]schema.ArgumentInfo{
+          "headers": {
+            Type: schema.NewNamedType("JSON").Encode(),
+          },
+          "input": {
+            Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("BaseAuthor"))).Encode(),
+          },
+          "other": {
+            Type: schema.NewNullableType(schema.NewNamedType("GetCustomHeadersOther_int")).Encode(),
+          },
+        },
+      },
 		},
 		ScalarTypes: schema.SchemaResponseScalarTypes{
       "BigInt": schema.ScalarType{
@@ -1082,6 +1449,11 @@ func GetConnectorSchema() *schema.SchemaResponse {
 		  	AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
 		  	ComparisonOperators: map[string]schema.ComparisonOperatorDefinition{},
         Representation:      schema.NewTypeRepresentationJSON().Encode(),
+    	},
+      "Date": schema.ScalarType{
+		  	AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},
+		  	ComparisonOperators: map[string]schema.ComparisonOperatorDefinition{},
+        Representation:      schema.NewTypeRepresentationDate().Encode(),
     	},
       "Float32": schema.ScalarType{
 		  	AggregateFunctions:  schema.ScalarTypeAggregateFunctions{},

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.json
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.json
@@ -1424,6 +1424,690 @@
               "type": "named"
             }
           }
+        },
+        "array_bigint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "BigInt",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_bigint_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "BigInt",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_bool_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Boolean",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_bool_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Boolean",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Float32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float32_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Float32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Float64",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float64_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Float64",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int16",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int16_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int16",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int32_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int64",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int64_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int64",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int8",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int8_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int8",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_json_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_json_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "JSON",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_raw_json_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "RawJSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_raw_json_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "RawJSON",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_string_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_string_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "String",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_time_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "TimestampTZ",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_time_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "TimestampTZ",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int16",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint16_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int16",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint32_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int64",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint64_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int64",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int8",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint8_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int8",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uuid_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "UUID",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uuid_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "UUID",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "bigint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "BigInt",
+              "type": "named"
+            }
+          }
+        },
+        "bool_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Boolean",
+              "type": "named"
+            }
+          }
+        },
+        "date_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Date",
+              "type": "named"
+            }
+          }
+        },
+        "float32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Float32",
+              "type": "named"
+            }
+          }
+        },
+        "float64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Float64",
+              "type": "named"
+            }
+          }
+        },
+        "int16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int16",
+              "type": "named"
+            }
+          }
+        },
+        "int32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "int64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          }
+        },
+        "int8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int8",
+              "type": "named"
+            }
+          }
+        },
+        "int_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "string_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "time_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "TimestampTZ",
+              "type": "named"
+            }
+          }
+        },
+        "uint16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int16",
+              "type": "named"
+            }
+          }
+        },
+        "uint32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "uint64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          }
+        },
+        "uint8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int8",
+              "type": "named"
+            }
+          }
+        },
+        "uint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "url_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "URL",
+              "type": "named"
+            }
+          }
+        },
+        "uuid_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "UUID",
+              "type": "named"
+            }
+          }
         }
       },
       "name": "getTypes",
@@ -1547,6 +2231,31 @@
           "type": {
             "name": "String",
             "type": "named"
+          }
+        }
+      }
+    },
+    "CustomHeadersResult_array_nullable_BaseAuthor": {
+      "fields": {
+        "Response": {
+          "type": {
+            "element_type": {
+              "type": "nullable",
+              "underlying_type": {
+                "name": "BaseAuthor",
+                "type": "named"
+              }
+            },
+            "type": "array"
+          }
+        },
+        "headers": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "JSON",
+              "type": "named"
+            }
           }
         }
       }
@@ -2993,6 +3702,690 @@
               "type": "named"
             }
           }
+        },
+        "array_bigint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "BigInt",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_bigint_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "BigInt",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_bool_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Boolean",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_bool_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Boolean",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Float32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float32_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Float32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Float64",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_float64_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Float64",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int16",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int16_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int16",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int32_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int64",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int64_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int64",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int8",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int8_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int8",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_int_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_json_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "JSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_json_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "JSON",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_raw_json_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "RawJSON",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_raw_json_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "RawJSON",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_string_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_string_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "String",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_time_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "TimestampTZ",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_time_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "TimestampTZ",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int16",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint16_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int16",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint32_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int64",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint64_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int64",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int8",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint8_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int8",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "Int32",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uint_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "Int32",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uuid_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "UUID",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "array_uuid_ptr_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "type": "nullable",
+                "underlying_type": {
+                  "name": "UUID",
+                  "type": "named"
+                }
+              },
+              "type": "array"
+            }
+          }
+        },
+        "bigint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "BigInt",
+              "type": "named"
+            }
+          }
+        },
+        "bool_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Boolean",
+              "type": "named"
+            }
+          }
+        },
+        "date_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Date",
+              "type": "named"
+            }
+          }
+        },
+        "float32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Float32",
+              "type": "named"
+            }
+          }
+        },
+        "float64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Float64",
+              "type": "named"
+            }
+          }
+        },
+        "int16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int16",
+              "type": "named"
+            }
+          }
+        },
+        "int32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "int64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          }
+        },
+        "int8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int8",
+              "type": "named"
+            }
+          }
+        },
+        "int_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "string_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "String",
+              "type": "named"
+            }
+          }
+        },
+        "time_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "TimestampTZ",
+              "type": "named"
+            }
+          }
+        },
+        "uint16_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int16",
+              "type": "named"
+            }
+          }
+        },
+        "uint32_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "uint64_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int64",
+              "type": "named"
+            }
+          }
+        },
+        "uint8_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int8",
+              "type": "named"
+            }
+          }
+        },
+        "uint_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "Int32",
+              "type": "named"
+            }
+          }
+        },
+        "url_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "URL",
+              "type": "named"
+            }
+          }
+        },
+        "uuid_empty": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "UUID",
+              "type": "named"
+            }
+          }
         }
       }
     },
@@ -3155,6 +4548,45 @@
         },
         "type": "array"
       }
+    },
+    {
+      "arguments": {
+        "headers": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
+        },
+        "input": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "BaseAuthor",
+                "type": "named"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "other": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "name": "GetCustomHeadersOther_int",
+              "type": "named"
+            }
+          }
+        }
+      },
+      "name": "doCustomHeaders",
+      "result_type": {
+        "type": "nullable",
+        "underlying_type": {
+          "name": "CustomHeadersResult_array_nullable_BaseAuthor",
+          "type": "named"
+        }
+      }
     }
   ],
   "scalar_types": {
@@ -3184,6 +4616,13 @@
       "comparison_operators": {},
       "representation": {
         "type": "json"
+      }
+    },
+    "Date": {
+      "aggregate_functions": {},
+      "comparison_operators": {},
+      "representation": {
+        "type": "date"
       }
     },
     "Float32": {

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/source/functions/prefix.go
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/source/functions/prefix.go
@@ -236,6 +236,65 @@ type GetTypesArguments struct {
 	RawJSONPtr *json.RawMessage
 	Bytes      scalar.Bytes
 	BytesPtr   *scalar.Bytes
+
+	UUIDEmpty    uuid.UUID     `json:"uuid_empty,omitempty"`
+	BoolEmpty    bool          `json:"bool_empty,omitempty"`
+	StringEmpty  string        `json:"string_empty,omitempty"`
+	IntEmpty     int           `json:"int_empty,omitempty"`
+	Int8Empty    int8          `json:"int8_empty,omitempty"`
+	Int16Empty   int16         `json:"int16_empty,omitempty"`
+	Int32Empty   int32         `json:"int32_empty,omitempty"`
+	Int64Empty   int64         `json:"int64_empty,omitempty"`
+	UintEmpty    uint          `json:"uint_empty,omitempty"`
+	Uint8Empty   uint8         `json:"uint8_empty,omitempty"`
+	Uint16Empty  uint16        `json:"uint16_empty,omitempty"`
+	Uint32Empty  uint32        `json:"uint32_empty,omitempty"`
+	Uint64Empty  uint64        `json:"uint64_empty,omitempty"`
+	Float32Empty float32       `json:"float32_empty,omitempty"`
+	Float64Empty float64       `json:"float64_empty,omitempty"`
+	TimeEmpty    time.Time     `json:"time_empty,omitempty"`
+	BigIntEmpty  scalar.BigInt `json:"bigint_empty,omitempty"`
+	DateEmpty    scalar.Date   `json:"date_empty,omitempty"`
+	URLEmpty     scalar.URL    `json:"url_empty,omitempty"`
+
+	ArrayBoolEmpty       []bool             `json:"array_bool_empty,omitempty"`
+	ArrayStringEmpty     []string           `json:"array_string_empty,omitempty"`
+	ArrayIntEmpty        []int              `json:"array_int_empty,omitempty"`
+	ArrayInt8Empty       []int8             `json:"array_int8_empty,omitempty"`
+	ArrayInt16Empty      []int16            `json:"array_int16_empty,omitempty"`
+	ArrayInt32Empty      []int32            `json:"array_int32_empty,omitempty"`
+	ArrayInt64Empty      []int64            `json:"array_int64_empty,omitempty"`
+	ArrayUintEmpty       []uint             `json:"array_uint_empty,omitempty"`
+	ArrayUint8Empty      []uint8            `json:"array_uint8_empty,omitempty"`
+	ArrayUint16Empty     []uint16           `json:"array_uint16_empty,omitempty"`
+	ArrayUint32Empty     []uint32           `json:"array_uint32_empty,omitempty"`
+	ArrayUint64Empty     []uint64           `json:"array_uint64_empty,omitempty"`
+	ArrayFloat32Empty    []float32          `json:"array_float32_empty,omitempty"`
+	ArrayFloat64Empty    []float64          `json:"array_float64_empty,omitempty"`
+	ArrayUUIDEmpty       []uuid.UUID        `json:"array_uuid_empty,omitempty"`
+	ArrayBoolPtrEmpty    []*bool            `json:"array_bool_ptr_empty,omitempty"`
+	ArrayStringPtrEmpty  []*string          `json:"array_string_ptr_empty,omitempty"`
+	ArrayIntPtrEmpty     []*int             `json:"array_int_ptr_empty,omitempty"`
+	ArrayInt8PtrEmpty    []*int8            `json:"array_int8_ptr_empty,omitempty"`
+	ArrayInt16PtrEmpty   []*int16           `json:"array_int16_ptr_empty,omitempty"`
+	ArrayInt32PtrEmpty   []*int32           `json:"array_int32_ptr_empty,omitempty"`
+	ArrayInt64PtrEmpty   []*int64           `json:"array_int64_ptr_empty,omitempty"`
+	ArrayUintPtrEmpty    []*uint            `json:"array_uint_ptr_empty,omitempty"`
+	ArrayUint8PtrEmpty   []*uint8           `json:"array_uint8_ptr_empty,omitempty"`
+	ArrayUint16PtrEmpty  []*uint16          `json:"array_uint16_ptr_empty,omitempty"`
+	ArrayUint32PtrEmpty  []*uint32          `json:"array_uint32_ptr_empty,omitempty"`
+	ArrayUint64PtrEmpty  []*uint64          `json:"array_uint64_ptr_empty,omitempty"`
+	ArrayFloat32PtrEmpty []*float32         `json:"array_float32_ptr_empty,omitempty"`
+	ArrayFloat64PtrEmpty []*float64         `json:"array_float64_ptr_empty,omitempty"`
+	ArrayUUIDPtrEmpty    []*uuid.UUID       `json:"array_uuid_ptr_empty,omitempty"`
+	ArrayJSONEmpty       []any              `json:"array_json_empty,omitempty"`
+	ArrayJSONPtrEmpty    []*interface{}     `json:"array_json_ptr_empty,omitempty"`
+	ArrayRawJSONEmpty    []json.RawMessage  `json:"array_raw_json_empty,omitempty"`
+	ArrayRawJSONPtrEmpty []*json.RawMessage `json:"array_raw_json_ptr_empty,omitempty"`
+	ArrayBigIntEmpty     []scalar.BigInt    `json:"array_bigint_empty,omitempty"`
+	ArrayBigIntPtrEmpty  []*scalar.BigInt   `json:"array_bigint_ptr_empty,omitempty"`
+	ArrayTimeEmpty       []time.Time        `json:"array_time_empty,omitempty"`
+	ArrayTimePtrEmpty    []*time.Time       `json:"array_time_ptr_empty,omitempty"`
 }
 
 func FunctionGetTypes(ctx context.Context, state *types.State, arguments *GetTypesArguments) (*GetTypesArguments, error) {
@@ -278,11 +337,11 @@ func FunctionGetCustomHeaders(ctx context.Context, state *types.State, arguments
 	}, nil
 }
 
-// type CustomHeadersResult[T any] struct {
-// 	Headers  map[string]string `json:"headers"`
-// 	Response T
-// }
+type CustomHeadersResult[T any] struct {
+	Headers  map[string]string `json:"headers,omitempty"`
+	Response T
+}
 
-// func ProcedureDoCustomHeaders(ctx context.Context, state *types.State, arguments *GetCustomHeadersArguments[*[]BaseAuthor, int]) (*CustomHeadersResult[[]*BaseAuthor], error) {
-// 	return &CustomHeadersResult[[]*BaseAuthor]{}, nil
-// }
+func ProcedureDoCustomHeaders(ctx context.Context, state *types.State, arguments *GetCustomHeadersArguments[*[]BaseAuthor, int]) (*CustomHeadersResult[[]*BaseAuthor], error) {
+	return &CustomHeadersResult[[]*BaseAuthor]{}, nil
+}

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/source/functions/prefix.go
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/source/functions/prefix.go
@@ -295,6 +295,8 @@ type GetTypesArguments struct {
 	ArrayBigIntPtrEmpty  []*scalar.BigInt   `json:"array_bigint_ptr_empty,omitempty"`
 	ArrayTimeEmpty       []time.Time        `json:"array_time_empty,omitempty"`
 	ArrayTimePtrEmpty    []*time.Time       `json:"array_time_ptr_empty,omitempty"`
+
+	IgnoredField string `json:"-"`
 }
 
 func FunctionGetTypes(ctx context.Context, state *types.State, arguments *GetTypesArguments) (*GetTypesArguments, error) {

--- a/cmd/hasura-ndc-go/command/internal/testdata/subdir/expected/schema.json
+++ b/cmd/hasura-ndc-go/command/internal/testdata/subdir/expected/schema.json
@@ -41,11 +41,14 @@
         },
         "tags": {
           "type": {
-            "element_type": {
-              "name": "String",
-              "type": "named"
-            },
-            "type": "array"
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
           }
         }
       },
@@ -95,11 +98,14 @@
         },
         "tags": {
           "type": {
-            "element_type": {
-              "name": "String",
-              "type": "named"
-            },
-            "type": "array"
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
           }
         }
       }
@@ -138,11 +144,14 @@
         },
         "tags": {
           "type": {
-            "element_type": {
-              "name": "String",
-              "type": "named"
-            },
-            "type": "array"
+            "type": "nullable",
+            "underlying_type": {
+              "element_type": {
+                "name": "String",
+                "type": "named"
+              },
+              "type": "array"
+            }
           }
         }
       }

--- a/example/codegen/connector_test.go
+++ b/example/codegen/connector_test.go
@@ -280,7 +280,7 @@ func TestQueryGetTypes(t *testing.T) {
 						"value": {
 							"id": "1",
 							"duration": 10,
-							"tags": [],
+							"tags": null,
 							"created_at": "2024-03-05T05:00:00Z"
 						}
 					},

--- a/example/codegen/schema.generated.go
+++ b/example/codegen/schema.generated.go
@@ -29,7 +29,7 @@ func GetConnectorSchema() *schema.SchemaResponse {
 						Type: schema.NewNullableType(schema.NewNamedType("AuthorStatus")).Encode(),
 					},
 					"tags": schema.ObjectField{
-						Type: schema.NewArrayType(schema.NewNamedType("String")).Encode(),
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("String"))).Encode(),
 					},
 				},
 			},
@@ -86,7 +86,7 @@ func GetConnectorSchema() *schema.SchemaResponse {
 						Type: schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("BaseAuthor"))).Encode(),
 					},
 					"headers": schema.ObjectField{
-						Type: schema.NewNamedType("JSON").Encode(),
+						Type: schema.NewNullableType(schema.NewNamedType("JSON")).Encode(),
 					},
 				},
 			},
@@ -565,6 +565,186 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"UintPtr": schema.ObjectField{
 						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"array_bigint_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("BigInt"))).Encode(),
+					},
+					"array_bigint_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("BigInt")))).Encode(),
+					},
+					"array_bool_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Boolean"))).Encode(),
+					},
+					"array_bool_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Boolean")))).Encode(),
+					},
+					"array_float32_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float32"))).Encode(),
+					},
+					"array_float32_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float32")))).Encode(),
+					},
+					"array_float64_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float64"))).Encode(),
+					},
+					"array_float64_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float64")))).Encode(),
+					},
+					"array_int16_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+					},
+					"array_int16_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+					},
+					"array_int32_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_int32_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_int64_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+					},
+					"array_int64_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+					},
+					"array_int8_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+					},
+					"array_int8_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+					},
+					"array_int_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_int_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_json_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("JSON"))).Encode(),
+					},
+					"array_json_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("JSON")))).Encode(),
+					},
+					"array_raw_json_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("RawJSON"))).Encode(),
+					},
+					"array_raw_json_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("RawJSON")))).Encode(),
+					},
+					"array_string_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("String"))).Encode(),
+					},
+					"array_string_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("String")))).Encode(),
+					},
+					"array_time_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("TimestampTZ"))).Encode(),
+					},
+					"array_time_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("TimestampTZ")))).Encode(),
+					},
+					"array_uint16_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+					},
+					"array_uint16_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+					},
+					"array_uint32_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_uint32_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_uint64_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+					},
+					"array_uint64_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+					},
+					"array_uint8_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+					},
+					"array_uint8_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+					},
+					"array_uint_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_uint_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_uuid_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("UUID"))).Encode(),
+					},
+					"array_uuid_ptr_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("UUID")))).Encode(),
+					},
+					"bigint_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("BigInt")).Encode(),
+					},
+					"bool_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Boolean")).Encode(),
+					},
+					"custom_scalar_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("CommentString")).Encode(),
+					},
+					"date_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Date")).Encode(),
+					},
+					"enum_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("SomeEnum")).Encode(),
+					},
+					"float32_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Float32")).Encode(),
+					},
+					"float64_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Float64")).Encode(),
+					},
+					"int16_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+					},
+					"int32_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"int64_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+					},
+					"int8_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+					},
+					"int_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"string_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),
+					},
+					"text_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),
+					},
+					"time_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("TimestampTZ")).Encode(),
+					},
+					"uint16_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+					},
+					"uint32_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"uint64_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+					},
+					"uint8_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+					},
+					"uint_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"url_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("URL")).Encode(),
+					},
+					"uuid_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("UUID")).Encode(),
 					},
 				},
 			},
@@ -1097,6 +1277,186 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"UintPtr": {
 						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"array_bigint_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("BigInt"))).Encode(),
+					},
+					"array_bigint_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("BigInt")))).Encode(),
+					},
+					"array_bool_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Boolean"))).Encode(),
+					},
+					"array_bool_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Boolean")))).Encode(),
+					},
+					"array_float32_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float32"))).Encode(),
+					},
+					"array_float32_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float32")))).Encode(),
+					},
+					"array_float64_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Float64"))).Encode(),
+					},
+					"array_float64_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Float64")))).Encode(),
+					},
+					"array_int16_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+					},
+					"array_int16_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+					},
+					"array_int32_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_int32_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_int64_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+					},
+					"array_int64_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+					},
+					"array_int8_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+					},
+					"array_int8_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+					},
+					"array_int_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_int_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_json_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("JSON"))).Encode(),
+					},
+					"array_json_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("JSON")))).Encode(),
+					},
+					"array_raw_json_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("RawJSON"))).Encode(),
+					},
+					"array_raw_json_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("RawJSON")))).Encode(),
+					},
+					"array_string_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("String"))).Encode(),
+					},
+					"array_string_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("String")))).Encode(),
+					},
+					"array_time_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("TimestampTZ"))).Encode(),
+					},
+					"array_time_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("TimestampTZ")))).Encode(),
+					},
+					"array_uint16_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int16"))).Encode(),
+					},
+					"array_uint16_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int16")))).Encode(),
+					},
+					"array_uint32_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_uint32_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_uint64_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int64"))).Encode(),
+					},
+					"array_uint64_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int64")))).Encode(),
+					},
+					"array_uint8_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int8"))).Encode(),
+					},
+					"array_uint8_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int8")))).Encode(),
+					},
+					"array_uint_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("Int32"))).Encode(),
+					},
+					"array_uint_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("Int32")))).Encode(),
+					},
+					"array_uuid_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("UUID"))).Encode(),
+					},
+					"array_uuid_ptr_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("UUID")))).Encode(),
+					},
+					"bigint_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("BigInt")).Encode(),
+					},
+					"bool_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Boolean")).Encode(),
+					},
+					"custom_scalar_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("CommentString")).Encode(),
+					},
+					"date_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Date")).Encode(),
+					},
+					"enum_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("SomeEnum")).Encode(),
+					},
+					"float32_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Float32")).Encode(),
+					},
+					"float64_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Float64")).Encode(),
+					},
+					"int16_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+					},
+					"int32_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"int64_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+					},
+					"int8_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+					},
+					"int_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"string_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),
+					},
+					"text_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),
+					},
+					"time_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("TimestampTZ")).Encode(),
+					},
+					"uint16_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int16")).Encode(),
+					},
+					"uint32_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"uint64_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int64")).Encode(),
+					},
+					"uint8_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int8")).Encode(),
+					},
+					"uint_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"url_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("URL")).Encode(),
+					},
+					"uuid_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("UUID")).Encode(),
 					},
 				},
 			},

--- a/example/codegen/schema.generated.go
+++ b/example/codegen/schema.generated.go
@@ -566,6 +566,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					"UintPtr": schema.ObjectField{
 						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
 					},
+					"any_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("JSON")).Encode(),
+					},
 					"array_bigint_empty": schema.ObjectField{
 						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("BigInt"))).Encode(),
 					},
@@ -625,6 +628,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"array_json_ptr_empty": schema.ObjectField{
 						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("JSON")))).Encode(),
+					},
+					"array_map_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("JSON"))).Encode(),
 					},
 					"array_raw_json_empty": schema.ObjectField{
 						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("RawJSON"))).Encode(),
@@ -715,6 +721,12 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"int_empty": schema.ObjectField{
 						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"map_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("JSON")).Encode(),
+					},
+					"raw_json_empty": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewNamedType("RawJSON")).Encode(),
 					},
 					"string_empty": schema.ObjectField{
 						Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),
@@ -1278,6 +1290,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					"UintPtr": {
 						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
 					},
+					"any_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("JSON")).Encode(),
+					},
 					"array_bigint_empty": {
 						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("BigInt"))).Encode(),
 					},
@@ -1337,6 +1352,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"array_json_ptr_empty": {
 						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNullableType(schema.NewNamedType("JSON")))).Encode(),
+					},
+					"array_map_empty": {
+						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("JSON"))).Encode(),
 					},
 					"array_raw_json_empty": {
 						Type: schema.NewNullableType(schema.NewArrayType(schema.NewNamedType("RawJSON"))).Encode(),
@@ -1427,6 +1445,12 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"int_empty": {
 						Type: schema.NewNullableType(schema.NewNamedType("Int32")).Encode(),
+					},
+					"map_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("JSON")).Encode(),
+					},
+					"raw_json_empty": {
+						Type: schema.NewNullableType(schema.NewNamedType("RawJSON")).Encode(),
 					},
 					"string_empty": {
 						Type: schema.NewNullableType(schema.NewNamedType("String")).Encode(),

--- a/example/codegen/types/arguments/arguments.go
+++ b/example/codegen/types/arguments/arguments.go
@@ -163,6 +163,68 @@ type GetTypesArguments struct {
 	RawJSONPtr *json.RawMessage
 	Bytes      scalar.Bytes
 	BytesPtr   *scalar.Bytes
+
+	UUIDEmpty         uuid.UUID         `json:"uuid_empty,omitempty"`
+	BoolEmpty         bool              `json:"bool_empty,omitempty"`
+	StringEmpty       string            `json:"string_empty,omitempty"`
+	IntEmpty          int               `json:"int_empty,omitempty"`
+	Int8Empty         int8              `json:"int8_empty,omitempty"`
+	Int16Empty        int16             `json:"int16_empty,omitempty"`
+	Int32Empty        int32             `json:"int32_empty,omitempty"`
+	Int64Empty        int64             `json:"int64_empty,omitempty"`
+	UintEmpty         uint              `json:"uint_empty,omitempty"`
+	Uint8Empty        uint8             `json:"uint8_empty,omitempty"`
+	Uint16Empty       uint16            `json:"uint16_empty,omitempty"`
+	Uint32Empty       uint32            `json:"uint32_empty,omitempty"`
+	Uint64Empty       uint64            `json:"uint64_empty,omitempty"`
+	Float32Empty      float32           `json:"float32_empty,omitempty"`
+	Float64Empty      float64           `json:"float64_empty,omitempty"`
+	TimeEmpty         time.Time         `json:"time_empty,omitempty"`
+	TextEmpty         types.Text        `json:"text_empty,omitempty"`
+	CustomScalarEmpty types.CommentText `json:"custom_scalar_empty,omitempty"`
+	EnumEmpty         types.SomeEnum    `json:"enum_empty,omitempty"`
+	BigIntEmpty       scalar.BigInt     `json:"bigint_empty,omitempty"`
+	DateEmpty         scalar.Date       `json:"date_empty,omitempty"`
+	URLEmpty          scalar.URL        `json:"url_empty,omitempty"`
+
+	ArrayBoolEmpty       []bool             `json:"array_bool_empty,omitempty"`
+	ArrayStringEmpty     []string           `json:"array_string_empty,omitempty"`
+	ArrayIntEmpty        []int              `json:"array_int_empty,omitempty"`
+	ArrayInt8Empty       []int8             `json:"array_int8_empty,omitempty"`
+	ArrayInt16Empty      []int16            `json:"array_int16_empty,omitempty"`
+	ArrayInt32Empty      []int32            `json:"array_int32_empty,omitempty"`
+	ArrayInt64Empty      []int64            `json:"array_int64_empty,omitempty"`
+	ArrayUintEmpty       []uint             `json:"array_uint_empty,omitempty"`
+	ArrayUint8Empty      []uint8            `json:"array_uint8_empty,omitempty"`
+	ArrayUint16Empty     []uint16           `json:"array_uint16_empty,omitempty"`
+	ArrayUint32Empty     []uint32           `json:"array_uint32_empty,omitempty"`
+	ArrayUint64Empty     []uint64           `json:"array_uint64_empty,omitempty"`
+	ArrayFloat32Empty    []float32          `json:"array_float32_empty,omitempty"`
+	ArrayFloat64Empty    []float64          `json:"array_float64_empty,omitempty"`
+	ArrayUUIDEmpty       []uuid.UUID        `json:"array_uuid_empty,omitempty"`
+	ArrayBoolPtrEmpty    []*bool            `json:"array_bool_ptr_empty,omitempty"`
+	ArrayStringPtrEmpty  []*string          `json:"array_string_ptr_empty,omitempty"`
+	ArrayIntPtrEmpty     []*int             `json:"array_int_ptr_empty,omitempty"`
+	ArrayInt8PtrEmpty    []*int8            `json:"array_int8_ptr_empty,omitempty"`
+	ArrayInt16PtrEmpty   []*int16           `json:"array_int16_ptr_empty,omitempty"`
+	ArrayInt32PtrEmpty   []*int32           `json:"array_int32_ptr_empty,omitempty"`
+	ArrayInt64PtrEmpty   []*int64           `json:"array_int64_ptr_empty,omitempty"`
+	ArrayUintPtrEmpty    []*uint            `json:"array_uint_ptr_empty,omitempty"`
+	ArrayUint8PtrEmpty   []*uint8           `json:"array_uint8_ptr_empty,omitempty"`
+	ArrayUint16PtrEmpty  []*uint16          `json:"array_uint16_ptr_empty,omitempty"`
+	ArrayUint32PtrEmpty  []*uint32          `json:"array_uint32_ptr_empty,omitempty"`
+	ArrayUint64PtrEmpty  []*uint64          `json:"array_uint64_ptr_empty,omitempty"`
+	ArrayFloat32PtrEmpty []*float32         `json:"array_float32_ptr_empty,omitempty"`
+	ArrayFloat64PtrEmpty []*float64         `json:"array_float64_ptr_empty,omitempty"`
+	ArrayUUIDPtrEmpty    []*uuid.UUID       `json:"array_uuid_ptr_empty,omitempty"`
+	ArrayJSONEmpty       []any              `json:"array_json_empty,omitempty"`
+	ArrayJSONPtrEmpty    []*interface{}     `json:"array_json_ptr_empty,omitempty"`
+	ArrayRawJSONEmpty    []json.RawMessage  `json:"array_raw_json_empty,omitempty"`
+	ArrayRawJSONPtrEmpty []*json.RawMessage `json:"array_raw_json_ptr_empty,omitempty"`
+	ArrayBigIntEmpty     []scalar.BigInt    `json:"array_bigint_empty,omitempty"`
+	ArrayBigIntPtrEmpty  []*scalar.BigInt   `json:"array_bigint_ptr_empty,omitempty"`
+	ArrayTimeEmpty       []time.Time        `json:"array_time_empty,omitempty"`
+	ArrayTimePtrEmpty    []*time.Time       `json:"array_time_ptr_empty,omitempty"`
 }
 
 type GetCustomHeadersInput struct {

--- a/example/codegen/types/arguments/arguments.go
+++ b/example/codegen/types/arguments/arguments.go
@@ -186,6 +186,10 @@ type GetTypesArguments struct {
 	BigIntEmpty       scalar.BigInt     `json:"bigint_empty,omitempty"`
 	DateEmpty         scalar.Date       `json:"date_empty,omitempty"`
 	URLEmpty          scalar.URL        `json:"url_empty,omitempty"`
+	MapEmpty          map[string]any    `json:"map_empty,omitempty"`
+	ArrayMapEmpty     []map[string]any  `json:"array_map_empty,omitempty"`
+	JSONEmpty         any               `json:"any_empty,omitempty"`
+	RawJSONEmpty      json.RawMessage   `json:"raw_json_empty,omitempty"`
 
 	ArrayBoolEmpty       []bool             `json:"array_bool_empty,omitempty"`
 	ArrayStringEmpty     []string           `json:"array_string_empty,omitempty"`

--- a/example/codegen/types/arguments/types.generated.go
+++ b/example/codegen/types/arguments/types.generated.go
@@ -614,6 +614,10 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 	if err != nil {
 		return err
 	}
+	j.JSONEmpty, err = utils.GetArbitraryJSONDefault(input, "any_empty")
+	if err != nil {
+		return err
+	}
 	err = connector_Decoder.DecodeNullableObjectValue(&j.ArrayBigIntEmpty, input, "array_bigint_empty")
 	if err != nil {
 		return err
@@ -691,6 +695,10 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 		return err
 	}
 	j.ArrayJSONPtrEmpty, err = utils.GetArbitraryJSONPtrSliceDefault(input, "array_json_ptr_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.ArrayMapEmpty, input, "array_map_empty")
 	if err != nil {
 		return err
 	}
@@ -811,6 +819,14 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 		return err
 	}
 	j.IntEmpty, err = utils.GetIntDefault[int](input, "int_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.MapEmpty, input, "map_empty")
+	if err != nil {
+		return err
+	}
+	j.RawJSONEmpty, err = utils.GetRawJSONDefault(input, "raw_json_empty")
 	if err != nil {
 		return err
 	}
@@ -1040,6 +1056,7 @@ func (j GetTypesArguments) ToMap() map[string]any {
 	r["Uint8"] = j.Uint8
 	r["Uint8Ptr"] = j.Uint8Ptr
 	r["UintPtr"] = j.UintPtr
+	r["any_empty"] = j.JSONEmpty
 	r["array_bigint_empty"] = j.ArrayBigIntEmpty
 	r["array_bigint_ptr_empty"] = j.ArrayBigIntPtrEmpty
 	r["array_bool_empty"] = j.ArrayBoolEmpty
@@ -1060,6 +1077,7 @@ func (j GetTypesArguments) ToMap() map[string]any {
 	r["array_int_ptr_empty"] = j.ArrayIntPtrEmpty
 	r["array_json_empty"] = j.ArrayJSONEmpty
 	r["array_json_ptr_empty"] = j.ArrayJSONPtrEmpty
+	r["array_map_empty"] = j.ArrayMapEmpty
 	r["array_raw_json_empty"] = j.ArrayRawJSONEmpty
 	r["array_raw_json_ptr_empty"] = j.ArrayRawJSONPtrEmpty
 	r["array_string_empty"] = j.ArrayStringEmpty
@@ -1090,6 +1108,8 @@ func (j GetTypesArguments) ToMap() map[string]any {
 	r["int64_empty"] = j.Int64Empty
 	r["int8_empty"] = j.Int8Empty
 	r["int_empty"] = j.IntEmpty
+	r["map_empty"] = j.MapEmpty
+	r["raw_json_empty"] = j.RawJSONEmpty
 	r["string_empty"] = j.StringEmpty
 	r["text_empty"] = j.TextEmpty
 	r["time_empty"] = j.TimeEmpty

--- a/example/codegen/types/arguments/types.generated.go
+++ b/example/codegen/types/arguments/types.generated.go
@@ -614,6 +614,246 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
 	if err != nil {
 		return err
 	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.ArrayBigIntEmpty, input, "array_bigint_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.ArrayBigIntPtrEmpty, input, "array_bigint_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayBoolEmpty, err = utils.GetBooleanSliceDefault(input, "array_bool_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayBoolPtrEmpty, err = utils.GetBooleanPtrSliceDefault(input, "array_bool_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayFloat32Empty, err = utils.GetFloatSliceDefault[float32](input, "array_float32_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayFloat32PtrEmpty, err = utils.GetFloatPtrSliceDefault[float32](input, "array_float32_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayFloat64Empty, err = utils.GetFloatSliceDefault[float64](input, "array_float64_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayFloat64PtrEmpty, err = utils.GetFloatPtrSliceDefault[float64](input, "array_float64_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt16Empty, err = utils.GetIntSliceDefault[int16](input, "array_int16_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt16PtrEmpty, err = utils.GetIntPtrSliceDefault[int16](input, "array_int16_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt32Empty, err = utils.GetIntSliceDefault[int32](input, "array_int32_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt32PtrEmpty, err = utils.GetIntPtrSliceDefault[int32](input, "array_int32_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt64Empty, err = utils.GetIntSliceDefault[int64](input, "array_int64_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt64PtrEmpty, err = utils.GetIntPtrSliceDefault[int64](input, "array_int64_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt8Empty, err = utils.GetIntSliceDefault[int8](input, "array_int8_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayInt8PtrEmpty, err = utils.GetIntPtrSliceDefault[int8](input, "array_int8_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayIntEmpty, err = utils.GetIntSliceDefault[int](input, "array_int_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayIntPtrEmpty, err = utils.GetIntPtrSliceDefault[int](input, "array_int_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayJSONEmpty, err = utils.GetArbitraryJSONSliceDefault(input, "array_json_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayJSONPtrEmpty, err = utils.GetArbitraryJSONPtrSliceDefault(input, "array_json_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayRawJSONEmpty, err = utils.GetRawJSONSliceDefault(input, "array_raw_json_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayRawJSONPtrEmpty, err = utils.GetRawJSONPtrSliceDefault(input, "array_raw_json_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayStringEmpty, err = utils.GetStringSliceDefault(input, "array_string_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayStringPtrEmpty, err = utils.GetStringPtrSliceDefault(input, "array_string_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayTimeEmpty, err = utils.GetDateTimeSliceDefault(input, "array_time_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayTimePtrEmpty, err = utils.GetDateTimePtrSliceDefault(input, "array_time_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint16Empty, err = utils.GetUintSliceDefault[uint16](input, "array_uint16_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint16PtrEmpty, err = utils.GetUintPtrSliceDefault[uint16](input, "array_uint16_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint32Empty, err = utils.GetUintSliceDefault[uint32](input, "array_uint32_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint32PtrEmpty, err = utils.GetUintPtrSliceDefault[uint32](input, "array_uint32_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint64Empty, err = utils.GetUintSliceDefault[uint64](input, "array_uint64_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint64PtrEmpty, err = utils.GetUintPtrSliceDefault[uint64](input, "array_uint64_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint8Empty, err = utils.GetUintSliceDefault[uint8](input, "array_uint8_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUint8PtrEmpty, err = utils.GetUintPtrSliceDefault[uint8](input, "array_uint8_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUintEmpty, err = utils.GetUintSliceDefault[uint](input, "array_uint_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUintPtrEmpty, err = utils.GetUintPtrSliceDefault[uint](input, "array_uint_ptr_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUUIDEmpty, err = utils.GetUUIDSliceDefault(input, "array_uuid_empty")
+	if err != nil {
+		return err
+	}
+	j.ArrayUUIDPtrEmpty, err = utils.GetUUIDPtrSliceDefault(input, "array_uuid_ptr_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.BigIntEmpty, input, "bigint_empty")
+	if err != nil {
+		return err
+	}
+	j.BoolEmpty, err = utils.GetBooleanDefault(input, "bool_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.CustomScalarEmpty, input, "custom_scalar_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.DateEmpty, input, "date_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.EnumEmpty, input, "enum_empty")
+	if err != nil {
+		return err
+	}
+	j.Float32Empty, err = utils.GetFloatDefault[float32](input, "float32_empty")
+	if err != nil {
+		return err
+	}
+	j.Float64Empty, err = utils.GetFloatDefault[float64](input, "float64_empty")
+	if err != nil {
+		return err
+	}
+	j.Int16Empty, err = utils.GetIntDefault[int16](input, "int16_empty")
+	if err != nil {
+		return err
+	}
+	j.Int32Empty, err = utils.GetIntDefault[int32](input, "int32_empty")
+	if err != nil {
+		return err
+	}
+	j.Int64Empty, err = utils.GetIntDefault[int64](input, "int64_empty")
+	if err != nil {
+		return err
+	}
+	j.Int8Empty, err = utils.GetIntDefault[int8](input, "int8_empty")
+	if err != nil {
+		return err
+	}
+	j.IntEmpty, err = utils.GetIntDefault[int](input, "int_empty")
+	if err != nil {
+		return err
+	}
+	j.StringEmpty, err = utils.GetStringDefault(input, "string_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.TextEmpty, input, "text_empty")
+	if err != nil {
+		return err
+	}
+	j.TimeEmpty, err = utils.GetDateTimeDefault(input, "time_empty")
+	if err != nil {
+		return err
+	}
+	j.Uint16Empty, err = utils.GetUintDefault[uint16](input, "uint16_empty")
+	if err != nil {
+		return err
+	}
+	j.Uint32Empty, err = utils.GetUintDefault[uint32](input, "uint32_empty")
+	if err != nil {
+		return err
+	}
+	j.Uint64Empty, err = utils.GetUintDefault[uint64](input, "uint64_empty")
+	if err != nil {
+		return err
+	}
+	j.Uint8Empty, err = utils.GetUintDefault[uint8](input, "uint8_empty")
+	if err != nil {
+		return err
+	}
+	j.UintEmpty, err = utils.GetUintDefault[uint](input, "uint_empty")
+	if err != nil {
+		return err
+	}
+	err = connector_Decoder.DecodeNullableObjectValue(&j.URLEmpty, input, "url_empty")
+	if err != nil {
+		return err
+	}
+	j.UUIDEmpty, err = utils.GetUUIDDefault(input, "uuid_empty")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -800,6 +1040,66 @@ func (j GetTypesArguments) ToMap() map[string]any {
 	r["Uint8"] = j.Uint8
 	r["Uint8Ptr"] = j.Uint8Ptr
 	r["UintPtr"] = j.UintPtr
+	r["array_bigint_empty"] = j.ArrayBigIntEmpty
+	r["array_bigint_ptr_empty"] = j.ArrayBigIntPtrEmpty
+	r["array_bool_empty"] = j.ArrayBoolEmpty
+	r["array_bool_ptr_empty"] = j.ArrayBoolPtrEmpty
+	r["array_float32_empty"] = j.ArrayFloat32Empty
+	r["array_float32_ptr_empty"] = j.ArrayFloat32PtrEmpty
+	r["array_float64_empty"] = j.ArrayFloat64Empty
+	r["array_float64_ptr_empty"] = j.ArrayFloat64PtrEmpty
+	r["array_int16_empty"] = j.ArrayInt16Empty
+	r["array_int16_ptr_empty"] = j.ArrayInt16PtrEmpty
+	r["array_int32_empty"] = j.ArrayInt32Empty
+	r["array_int32_ptr_empty"] = j.ArrayInt32PtrEmpty
+	r["array_int64_empty"] = j.ArrayInt64Empty
+	r["array_int64_ptr_empty"] = j.ArrayInt64PtrEmpty
+	r["array_int8_empty"] = j.ArrayInt8Empty
+	r["array_int8_ptr_empty"] = j.ArrayInt8PtrEmpty
+	r["array_int_empty"] = j.ArrayIntEmpty
+	r["array_int_ptr_empty"] = j.ArrayIntPtrEmpty
+	r["array_json_empty"] = j.ArrayJSONEmpty
+	r["array_json_ptr_empty"] = j.ArrayJSONPtrEmpty
+	r["array_raw_json_empty"] = j.ArrayRawJSONEmpty
+	r["array_raw_json_ptr_empty"] = j.ArrayRawJSONPtrEmpty
+	r["array_string_empty"] = j.ArrayStringEmpty
+	r["array_string_ptr_empty"] = j.ArrayStringPtrEmpty
+	r["array_time_empty"] = j.ArrayTimeEmpty
+	r["array_time_ptr_empty"] = j.ArrayTimePtrEmpty
+	r["array_uint16_empty"] = j.ArrayUint16Empty
+	r["array_uint16_ptr_empty"] = j.ArrayUint16PtrEmpty
+	r["array_uint32_empty"] = j.ArrayUint32Empty
+	r["array_uint32_ptr_empty"] = j.ArrayUint32PtrEmpty
+	r["array_uint64_empty"] = j.ArrayUint64Empty
+	r["array_uint64_ptr_empty"] = j.ArrayUint64PtrEmpty
+	r["array_uint8_empty"] = j.ArrayUint8Empty
+	r["array_uint8_ptr_empty"] = j.ArrayUint8PtrEmpty
+	r["array_uint_empty"] = j.ArrayUintEmpty
+	r["array_uint_ptr_empty"] = j.ArrayUintPtrEmpty
+	r["array_uuid_empty"] = j.ArrayUUIDEmpty
+	r["array_uuid_ptr_empty"] = j.ArrayUUIDPtrEmpty
+	r["bigint_empty"] = j.BigIntEmpty
+	r["bool_empty"] = j.BoolEmpty
+	r["custom_scalar_empty"] = j.CustomScalarEmpty
+	r["date_empty"] = j.DateEmpty
+	r["enum_empty"] = j.EnumEmpty
+	r["float32_empty"] = j.Float32Empty
+	r["float64_empty"] = j.Float64Empty
+	r["int16_empty"] = j.Int16Empty
+	r["int32_empty"] = j.Int32Empty
+	r["int64_empty"] = j.Int64Empty
+	r["int8_empty"] = j.Int8Empty
+	r["int_empty"] = j.IntEmpty
+	r["string_empty"] = j.StringEmpty
+	r["text_empty"] = j.TextEmpty
+	r["time_empty"] = j.TimeEmpty
+	r["uint16_empty"] = j.Uint16Empty
+	r["uint32_empty"] = j.Uint32Empty
+	r["uint64_empty"] = j.Uint64Empty
+	r["uint8_empty"] = j.Uint8Empty
+	r["uint_empty"] = j.UintEmpty
+	r["url_empty"] = j.URLEmpty
+	r["uuid_empty"] = j.UUIDEmpty
 
 	return r
 }

--- a/example/codegen/types/types.generated.go
+++ b/example/codegen/types/types.generated.go
@@ -31,7 +31,7 @@ func (j *Author) FromValue(input map[string]any) error {
 	if err != nil {
 		return err
 	}
-	j.Tags, err = utils.GetStringSlice(input, "tags")
+	j.Tags, err = utils.GetStringSliceDefault(input, "tags")
 	if err != nil {
 		return err
 	}

--- a/example/codegen/types/types.go
+++ b/example/codegen/types/types.go
@@ -46,7 +46,7 @@ type AuthorStatus string
 type Author struct {
 	ID        string        `json:"id"`
 	CreatedAt time.Time     `json:"created_at"`
-	Tags      []string      `json:"tags"`
+	Tags      []string      `json:"tags,omitempty"`
 	Status    *AuthorStatus `json:"status"`
 	Author    *Author       `json:"author"`
 }
@@ -57,6 +57,6 @@ type GetAuthorResult struct {
 }
 
 type CustomHeadersResult[T any] struct {
-	Headers  map[string]string `json:"headers"`
+	Headers  map[string]string `json:"headers,omitempty"`
 	Response T
 }

--- a/utils/decode.go
+++ b/utils/decode.go
@@ -98,7 +98,7 @@ func (d Decoder) DecodeValue(target any, value any) error {
 // fallback to mapstructure decoder.
 func (d Decoder) DecodeNullableValue(target any, value any) error {
 	err := d.decodeValue(target, value)
-	if err != nil && err != errValueRequired {
+	if err != nil && !errors.Is(err, errValueRequired) {
 		return err
 	}
 	return nil

--- a/utils/decode.go
+++ b/utils/decode.go
@@ -25,8 +25,10 @@ type (
 )
 
 var (
-	errIntRequired  = errors.New("the Int value must not be null")
-	errUintRequired = errors.New("the Uint value must not be null")
+	errIntRequired         = errors.New("the Int value must not be null")
+	errUintRequired        = errors.New("the Uint value must not be null")
+	errValueTargetRequired = errors.New("the decoded target must be a pointer and not null")
+	errValueRequired       = errors.New("the value must not be null")
 )
 
 // ValueDecoder abstracts a type with the FromValue method to decode any value.
@@ -89,27 +91,25 @@ func (d Decoder) DecodeNullableObjectValue(target any, object map[string]any, ke
 // DecodeValue tries to convert and set an unknown value into the target, the value must not be null
 // fallback to mapstructure decoder.
 func (d Decoder) DecodeValue(target any, value any) error {
-	if IsNil(value) {
-		return errors.New("the value must not be null")
-	}
 	return d.decodeValue(target, value)
 }
 
 // DecodeNullableValue tries to convert and set an unknown value into the target,
 // fallback to mapstructure decoder.
 func (d Decoder) DecodeNullableValue(target any, value any) error {
-	if IsNil(value) {
-		return nil
+	err := d.decodeValue(target, value)
+	if err != nil && err != errValueRequired {
+		return err
 	}
-	return d.decodeValue(target, value)
+	return nil
 }
 
 func (d Decoder) decodeValue(target any, value any) error {
 	if IsNil(target) {
-		return errors.New("the decoded target must be not null")
+		return errValueTargetRequired
 	}
 	if IsNil(value) {
-		return nil
+		return errValueRequired
 	}
 
 	switch t := target.(type) {
@@ -978,6 +978,21 @@ func GetArbitraryJSON(object map[string]any, key string) (any, error) {
 	return value, nil
 }
 
+// GetArbitraryJSONDefault get an arbitrary json value from object by key.
+// Return nil if the value does not exist
+func GetArbitraryJSONDefault(object map[string]any, key string) (any, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+
+	value, ok = UnwrapPointerFromAny(value)
+	if !ok {
+		return nil, nil
+	}
+	return value, nil
+}
+
 // GetNullableInt get an integer pointer from object by key.
 func GetNullableInt[T int | int8 | int16 | int32 | int64](object map[string]any, key string) (*T, error) {
 	value, ok := GetAny(object, key)
@@ -985,6 +1000,24 @@ func GetNullableInt[T int | int8 | int16 | int32 | int64](object map[string]any,
 		return nil, nil
 	}
 	result, err := DecodeNullableInt[T](value)
+	if err != nil {
+		return result, fmt.Errorf("%s: %w", key, err)
+	}
+	return result, nil
+}
+
+// GetIntDefault get an integer value from object by key.
+// Returns 0 if the field is null.
+func GetIntDefault[T int | int8 | int16 | int32 | int64](object map[string]any, key string) (T, error) {
+	value, ok := GetAny(object, key)
+	if !ok || value == nil {
+		return 0, nil
+	}
+	reflectValue, notNull := UnwrapPointerFromAnyToReflectValue(value)
+	if !notNull {
+		return 0, nil
+	}
+	result, err := DecodeIntReflection[T](reflectValue)
 	if err != nil {
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
@@ -1030,6 +1063,24 @@ func GetUint[T uint | uint8 | uint16 | uint32 | uint64](object map[string]any, k
 	return result, nil
 }
 
+// GetUintDefault gets an unsigned integer value from object by key.
+// Returns 0 if the field is null.
+func GetUintDefault[T uint | uint8 | uint16 | uint32 | uint64](object map[string]any, key string) (T, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return 0, nil
+	}
+	reflectValue, notNull := UnwrapPointerFromAnyToReflectValue(value)
+	if !notNull {
+		return 0, nil
+	}
+	result, err := DecodeUintReflection[T](reflectValue)
+	if err != nil {
+		return result, fmt.Errorf("%s: %w", key, err)
+	}
+	return result, nil
+}
+
 // GetNullableFloat get a float pointer from object by key.
 func GetNullableFloat[T float32 | float64](object map[string]any, key string) (*T, error) {
 	value, ok := GetAny(object, key)
@@ -1050,6 +1101,24 @@ func GetFloat[T float32 | float64](object map[string]any, key string) (T, error)
 		return 0, fmt.Errorf("field `%s` is required", key)
 	}
 	result, err := DecodeFloat[T](value)
+	if err != nil {
+		return result, fmt.Errorf("%s: %w", key, err)
+	}
+	return result, nil
+}
+
+// GetFloatDefault get a float value from object by key.
+// Returns 0 if the field is null.
+func GetFloatDefault[T float32 | float64](object map[string]any, key string) (T, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return 0, nil
+	}
+	reflectValue, notNull := UnwrapPointerFromAnyToReflectValue(value)
+	if !notNull {
+		return 0, nil
+	}
+	result, err := DecodeFloatReflection[T](reflectValue)
 	if err != nil {
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
@@ -1082,6 +1151,23 @@ func GetString(object map[string]any, key string) (string, error) {
 	return result, nil
 }
 
+// GetStringDefault get a string value from object by key.
+// Returns an empty string if the value is null
+func GetStringDefault(object map[string]any, key string) (string, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return "", nil
+	}
+	result, err := DecodeNullableStringReflection(reflect.ValueOf(value))
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return "", nil
+	}
+	return *result, nil
+}
+
 // GetNullableBoolean get a bool pointer from object by key.
 func GetNullableBoolean(object map[string]any, key string) (*bool, error) {
 	value, ok := GetAny(object, key)
@@ -1106,6 +1192,21 @@ func GetBoolean(object map[string]any, key string) (bool, error) {
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetBooleanDefault get a bool value from object by key.
+// Returns false if the value is null
+func GetBooleanDefault(object map[string]any, key string) (bool, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return false, nil
+	}
+
+	result, err := DecodeNullableBoolean(value)
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", key, err)
+	}
+	return result != nil && *result, nil
 }
 
 // GetNullableDateTime get a time.Time pointer from object by key.
@@ -1134,6 +1235,23 @@ func GetDateTime(object map[string]any, key string) (time.Time, error) {
 	return result, nil
 }
 
+// GetDateTimeDefault get a time.Time value from object by key.
+// Returns the empty time if the value is empty.
+func GetDateTimeDefault(object map[string]any, key string) (time.Time, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return time.Time{}, nil
+	}
+	result, err := DecodeNullableDateTime(value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return time.Time{}, nil
+	}
+	return *result, nil
+}
+
 // GetNullableDuration get a time.Duration pointer from object by key.
 func GetNullableDuration(object map[string]any, key string) (*time.Duration, error) {
 	value, ok := GetAny(object, key)
@@ -1158,6 +1276,23 @@ func GetDuration(object map[string]any, key string) (time.Duration, error) {
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetDurationDefault get a time.Duration value from object by key.
+// Returns 0 if the value is null.
+func GetDurationDefault(object map[string]any, key string) (time.Duration, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return 0, nil
+	}
+	result, err := DecodeNullableDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return 0, nil
+	}
+	return *result, nil
 }
 
 // DecodeUUID decodes UUID from string.
@@ -1237,15 +1372,35 @@ func GetNullableUUID(object map[string]any, key string) (*uuid.UUID, error) {
 	return result, nil
 }
 
+// GetUUIDDefault get an UUID value from object by key.
+// Returns uuid.Nil if the value is null
+func GetUUIDDefault(object map[string]any, key string) (uuid.UUID, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return uuid.Nil, nil
+	}
+	result, err := DecodeNullableUUID(value)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return uuid.Nil, nil
+	}
+	return *result, nil
+}
+
 // GetRawJSON get a raw json.RawMessage value from object by key.
 func GetRawJSON(object map[string]any, key string) (json.RawMessage, error) {
 	value, ok := GetAny(object, key)
-	if !ok || IsNil(value) {
+	if !ok {
 		return nil, fmt.Errorf("field %s is required", key)
 	}
 	result, err := DecodeNullableRawJSON(value)
 	if err != nil {
 		return nil, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("field %s must not be null", key)
 	}
 	return *result, nil
 }
@@ -1279,6 +1434,23 @@ func GetNullableRawJSON(object map[string]any, key string) (*json.RawMessage, er
 		return nil, nil
 	}
 	return DecodeNullableRawJSON(value)
+}
+
+// GetRawJSONDefault get a raw json.RawMessage value from object by key.
+// Returns nil if the value is empty
+func GetRawJSONDefault(object map[string]any, key string) (json.RawMessage, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableRawJSON(value)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 func decodeAnyValue(target any, value any, decodeHook mapstructure.DecodeHookFunc) error {

--- a/utils/decode_slice.go
+++ b/utils/decode_slice.go
@@ -164,6 +164,22 @@ func GetIntSlice[T int | int8 | int16 | int32 | int64](object map[string]any, ke
 	return result, nil
 }
 
+// GetIntSliceDefault get an integer slice from object by key.
+func GetIntSliceDefault[T int | int8 | int16 | int32 | int64](object map[string]any, key string) ([]T, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableIntSlice[T](value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetUintSlice get an unsigned integer slice from object by key.
 func GetUintSlice[T uint | uint8 | uint16 | uint32 | uint64](object map[string]any, key string) ([]T, error) {
 	value, ok := GetAny(object, key)
@@ -177,6 +193,22 @@ func GetUintSlice[T uint | uint8 | uint16 | uint32 | uint64](object map[string]a
 	return result, nil
 }
 
+// GetUintSliceDefault get an unsigned integer slice from object by key.
+func GetUintSliceDefault[T uint | uint8 | uint16 | uint32 | uint64](object map[string]any, key string) ([]T, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableUintSlice[T](value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetFloatSlice get a float slice from object by key.
 func GetFloatSlice[T float32 | float64](object map[string]any, key string) ([]T, error) {
 	value, ok := GetAny(object, key)
@@ -188,6 +220,22 @@ func GetFloatSlice[T float32 | float64](object map[string]any, key string) ([]T,
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetFloatSliceDefault get a float slice from object by key.
+func GetFloatSliceDefault[T float32 | float64](object map[string]any, key string) ([]T, error) {
+	value, ok := GetAny(object, key)
+	if !ok || value == nil {
+		return nil, nil
+	}
+	result, err := DecodeNullableFloatSlice[T](value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 // GetNullableIntPtrSlice get an integer pointer slice from object by key.
@@ -242,6 +290,22 @@ func GetIntPtrSlice[T int | int8 | int16 | int32 | int64](object map[string]any,
 	return result, nil
 }
 
+// GetIntPtrSliceDefault get an integer slice from object by key.
+func GetIntPtrSliceDefault[T int | int8 | int16 | int32 | int64](object map[string]any, key string) ([]*T, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableIntPtrSlice[T](value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetUintPtrSlice get an unsigned integer slice from object by key.
 func GetUintPtrSlice[T uint | uint8 | uint16 | uint32 | uint64](object map[string]any, key string) ([]*T, error) {
 	value, ok := GetAny(object, key)
@@ -255,6 +319,22 @@ func GetUintPtrSlice[T uint | uint8 | uint16 | uint32 | uint64](object map[strin
 	return result, nil
 }
 
+// GetUintPtrSliceDefault get an unsigned integer slice from object by key.
+func GetUintPtrSliceDefault[T uint | uint8 | uint16 | uint32 | uint64](object map[string]any, key string) ([]*T, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableUintPtrSlice[T](value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetFloatPtrSlice get a float slice from object by key.
 func GetFloatPtrSlice[T float32 | float64](object map[string]any, key string) ([]*T, error) {
 	value, ok := GetAny(object, key)
@@ -266,6 +346,22 @@ func GetFloatPtrSlice[T float32 | float64](object map[string]any, key string) ([
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetFloatPtrSliceDefault get a float slice from object by key.
+func GetFloatPtrSliceDefault[T float32 | float64](object map[string]any, key string) ([]*T, error) {
+	value, ok := GetAny(object, key)
+	if !ok || value == nil {
+		return nil, nil
+	}
+	result, err := DecodeNullableFloatPtrSlice[T](value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 // decodeNullableNumberSlice tries to convert an unknown value to a number slice.
@@ -417,6 +513,22 @@ func GetStringSlice(object map[string]any, key string) ([]string, error) {
 	return result, nil
 }
 
+// GetStringSliceDefault get a string slice value from object by key.
+func GetStringSliceDefault(object map[string]any, key string) ([]string, error) {
+	value, ok := GetAny(object, key)
+	if !ok || value == nil {
+		return nil, nil
+	}
+	result, err := DecodeNullableStringSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetNullableStringSlice get a string pointer slice from object by key.
 func GetNullableStringSlice(object map[string]any, key string) (*[]string, error) {
 	value, ok := GetAny(object, key)
@@ -441,6 +553,22 @@ func GetStringPtrSlice(object map[string]any, key string) ([]*string, error) {
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetStringPtrSliceDefault get a string pointer slice value from object by key.
+func GetStringPtrSliceDefault(object map[string]any, key string) ([]*string, error) {
+	value, ok := GetAny(object, key)
+	if !ok || value == nil {
+		return nil, nil
+	}
+	result, err := DecodeNullableStringPtrSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 // GetNullableStringPtrSlice get a nullable string pointer slice from object by key.
@@ -548,6 +676,22 @@ func GetBooleanSlice(object map[string]any, key string) ([]bool, error) {
 	return result, nil
 }
 
+// GetBooleanSliceDefault get a boolean slice value from object by key.
+func GetBooleanSliceDefault(object map[string]any, key string) ([]bool, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableBooleanSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetNullableBooleanSlice get a nullable boolean slice from object by key.
 func GetNullableBooleanSlice(object map[string]any, key string) (*[]bool, error) {
 	value, ok := GetAny(object, key)
@@ -572,6 +716,22 @@ func GetBooleanPtrSlice(object map[string]any, key string) ([]*bool, error) {
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetBooleanPtrSliceDefault get a boolean pointer slice value from object by key.
+func GetBooleanPtrSliceDefault(object map[string]any, key string) ([]*bool, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableBooleanPtrSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 // GetNullableBooleanPtrSlice get a nullable boolean slice from object by key.
@@ -676,6 +836,22 @@ func GetUUIDSlice(object map[string]any, key string) ([]uuid.UUID, error) {
 	return result, nil
 }
 
+// GetUUIDSliceDefault get an UUID slice from object by key.
+func GetUUIDSliceDefault(object map[string]any, key string) ([]uuid.UUID, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableUUIDSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetNullableUUIDSlice get an UUID pointer slice from object by key.
 func GetNullableUUIDSlice(object map[string]any, key string) (*[]uuid.UUID, error) {
 	value, ok := GetAny(object, key)
@@ -700,6 +876,22 @@ func GetUUIDPtrSlice(object map[string]any, key string) ([]*uuid.UUID, error) {
 		return nil, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetUUIDPtrSliceDefault get an UUID slice from object by key.
+func GetUUIDPtrSliceDefault(object map[string]any, key string) ([]*uuid.UUID, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableUUIDPtrSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 // GetNullableUUIDPtrSlice get an UUID pointer slice from object by key.
@@ -823,6 +1015,22 @@ func GetDateTimeSlice(object map[string]any, key string) ([]time.Time, error) {
 	return result, nil
 }
 
+// GetDateTimeSliceDefault get a time.Time slice from object by key.
+func GetDateTimeSliceDefault(object map[string]any, key string) ([]time.Time, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableDateTimeSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetNullableDateTimePtrSlice get a nullable time.Time pointer slice from object by key.
 func GetNullableDateTimePtrSlice(object map[string]any, key string) (*[]*time.Time, error) {
 	value, ok := GetAny(object, key)
@@ -847,6 +1055,22 @@ func GetDateTimePtrSlice(object map[string]any, key string) ([]*time.Time, error
 		return result, fmt.Errorf("%s: %w", key, err)
 	}
 	return result, nil
+}
+
+// GetDateTimePtrSliceDefault get a time.Time pointer slice from object by key.
+func GetDateTimePtrSliceDefault(object map[string]any, key string) ([]*time.Time, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableDateTimePtrSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 // DecodeNullableArbitraryJSONPtrSlice decodes a nullable arbitrary json pointer slice from object by key.
@@ -944,6 +1168,22 @@ func GetArbitraryJSONPtrSlice(object map[string]any, key string) ([]*any, error)
 	return DecodeArbitraryJSONPtrSlice(value)
 }
 
+// GetArbitraryJSONPtrSliceDefault get an arbitrary json pointer slice from object by key.
+func GetArbitraryJSONPtrSliceDefault(object map[string]any, key string) ([]*any, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableArbitraryJSONPtrSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetNullableArbitraryJSONSlice get a nullable arbitrary json slice from object by key.
 func GetNullableArbitraryJSONSlice(object map[string]any, key string) (*[]any, error) {
 	value, ok := GetAny(object, key)
@@ -953,13 +1193,29 @@ func GetNullableArbitraryJSONSlice(object map[string]any, key string) (*[]any, e
 	return DecodeNullableArbitraryJSONSlice(value)
 }
 
-// GetArbitraryJSON get an arbitrary json slice from object by key.
+// GetArbitraryJSONSlice get an arbitrary json slice from object by key.
 func GetArbitraryJSONSlice(object map[string]any, key string) ([]any, error) {
 	value, ok := GetAny(object, key)
 	if !ok || value == nil {
 		return nil, fmt.Errorf("field `%s` is required", key)
 	}
 	return DecodeArbitraryJSONSlice(value)
+}
+
+// GetArbitraryJSONSliceDefault get an arbitrary json slice from object by key.
+func GetArbitraryJSONSliceDefault(object map[string]any, key string) ([]any, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableArbitraryJSONSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }
 
 // DecodeNullableRawJSONSlice decodes a nullable json.RawMessage slice from object by key.
@@ -1059,6 +1315,22 @@ func GetRawJSONSlice(object map[string]any, key string) ([]json.RawMessage, erro
 	return DecodeRawJSONSlice(value)
 }
 
+// GetRawJSONSliceDefault get a raw json.RawMessage slice from object by key.
+func GetRawJSONSliceDefault(object map[string]any, key string) ([]json.RawMessage, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+	result, err := DecodeNullableRawJSONSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
+}
+
 // GetNullableRawJSONPtrSlice get a nullable json.RawMessage pointer slice from object by key.
 func GetNullableRawJSONPtrSlice(object map[string]any, key string) (*[]*json.RawMessage, error) {
 	value, ok := GetAny(object, key)
@@ -1075,4 +1347,21 @@ func GetRawJSONPtrSlice(object map[string]any, key string) ([]*json.RawMessage, 
 		return nil, fmt.Errorf("field %s is required", key)
 	}
 	return DecodeRawJSONPtrSlice(value)
+}
+
+// GetRawJSONPtrSliceDefault get a json.RawMessage pointer slice from object by key.
+func GetRawJSONPtrSliceDefault(object map[string]any, key string) ([]*json.RawMessage, error) {
+	value, ok := GetAny(object, key)
+	if !ok {
+		return nil, nil
+	}
+
+	result, err := DecodeNullableRawJSONPtrSlice(value)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", key, err)
+	}
+	if result == nil {
+		return nil, nil
+	}
+	return *result, nil
 }


### PR DESCRIPTION
Support tag options:

- `omitempty`: if this option is set, the field schema will be nullable even if the field type isn't a pointer.
- `-`: the object field is ignored.