### PR TITLE
fix: quote schema description and expose security utils for telemetry

### DIFF
--- a/cmd/hasura-ndc-go/command/internal/schema_template.go
+++ b/cmd/hasura-ndc-go/command/internal/schema_template.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/hasura/ndc-sdk-go/schema"
@@ -194,9 +195,9 @@ func (rcs RawConnectorSchema) writeScalarType(builder *strings.Builder, key stri
 
 func (rcs RawConnectorSchema) writeDescription(builder *strings.Builder, description *string) {
 	if description != nil {
-		builder.WriteString(`        Description: toPtr("`)
-		builder.WriteString(*description)
-		builder.WriteString("\"),\n")
+		builder.WriteString(`        Description: toPtr(`)
+		builder.WriteString(strconv.Quote(*description))
+		builder.WriteString("),\n")
 	}
 }
 

--- a/cmd/hasura-ndc-go/command/snapshots_gen.go
+++ b/cmd/hasura-ndc-go/command/snapshots_gen.go
@@ -149,6 +149,12 @@ func (cmd *genTestSnapshotsCommand) genFunction(fn *schema.FunctionInfo) error {
 
 	queryReq := currentRequest
 	if currentRequest == nil || cmd.args.Strategy == internal.WriteFileStrategyOverride {
+		if currentRequest == nil {
+			slog.Debug("can not find the request.json file at "+snapshotDir, slog.String("function", fn.Name))
+		} else {
+			slog.Debug("override request and response files", slog.String("function", fn.Name))
+		}
+
 		args, err := cmd.genQueryArguments(fn.Arguments)
 		if err != nil {
 			return fmt.Errorf("failed to generate arguments for %s function: %w", fn.Name, err)
@@ -256,6 +262,12 @@ func (cmd *genTestSnapshotsCommand) genProcedure(proc *schema.ProcedureInfo) err
 	}
 
 	if currentRequest == nil || cmd.args.Strategy == internal.WriteFileStrategyOverride {
+		if currentRequest == nil {
+			slog.Debug("can not find the request.json file at "+snapshotDir, slog.String("procedure", proc.Name))
+		} else {
+			slog.Debug("override request and response files", slog.String("procedure", proc.Name))
+		}
+
 		args, err := cmd.genOperationArguments(proc.Arguments)
 		if err != nil {
 			return fmt.Errorf("failed to generate arguments for %s procedure: %w", proc.Name, err)

--- a/connector/http.go
+++ b/connector/http.go
@@ -113,7 +113,7 @@ func (rt *router) Build() *http.ServeMux {
 
 			ctx := r.Context()
 			//lint:ignore SA1012 possible to set nil
-			span := trace.SpanFromContext(nil) //nolint:all
+			span := trace.SpanFromContext(nil) //nolint:contextcheck,staticcheck
 			spanName, spanOk := allowedTraceEndpoints[strings.ToLower(r.URL.Path)]
 			if spanOk {
 				ctx, span = rt.telemetry.Tracer.Start(
@@ -135,7 +135,7 @@ func (rt *router) Build() *http.ServeMux {
 			if isDebug {
 				requestLogData["headers"] = r.Header
 				if spanOk {
-					setSpanHeadersAttributes(span, "http.request.header", r.Header, isDebug)
+					SetSpanHeaderAttributes(span, "http.request.header", r.Header)
 				}
 				if r.Body != nil {
 					bodyBytes, err := io.ReadAll(r.Body)
@@ -257,7 +257,7 @@ func (rt *router) Build() *http.ServeMux {
 					span.SetAttributes(attribute.String("response.body", string(writer.body)))
 				}
 			}
-			setSpanHeadersAttributes(span, "http.response.header", w.Header(), isDebug)
+			SetSpanHeaderAttributes(span, "http.response.header", w.Header())
 
 			if writer.statusCode >= http.StatusBadRequest {
 				logger.Error(

--- a/connector/telemetry_test.go
+++ b/connector/telemetry_test.go
@@ -1,0 +1,54 @@
+package connector
+
+import (
+	"net/http"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNewTelemetryHeaders(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Input          http.Header
+		AllowedHeaders []string
+		Expected       http.Header
+	}{
+		{
+			Name: "basic",
+			Input: http.Header{
+				"Content-Type":  []string{"application/json"},
+				"Authorization": []string{"Bearer abcdefghijkxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+				"Api-Key":       []string{"abcxyz"},
+				"Secret-Key":    []string{"secret-key"},
+				"X-Empty":       []string{},
+			},
+			Expected: http.Header{
+				"Content-Type":  []string{"application/json"},
+				"Authorization": []string{"Bea*******(65)"},
+				"Api-Key":       []string{"******"},
+				"Secret-Key":    []string{"s*********"},
+			},
+		},
+		{
+			Name: "allowed_list",
+			Input: http.Header{
+				"Content-Type":  []string{"application/json"},
+				"Authorization": []string{"Bearer abcdefghijkxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},
+				"Api-Key":       []string{"abcxyz"},
+				"Secret-Key":    []string{"secret-key"},
+			},
+			AllowedHeaders: []string{"Content-Type", "Api-Key"},
+			Expected: http.Header{
+				"Content-Type": []string{"application/json"},
+				"Api-Key":      []string{"******"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.DeepEqual(t, tc.Expected, NewTelemetryHeaders(tc.Input, tc.AllowedHeaders...))
+		})
+	}
+}


### PR DESCRIPTION
- fix: quote escapes when generating connector schema.
- enhance and expose utilities for telemetry such as sensitive string masking.