### PR TITLE
codegen: fix scalar error message typo and parse directories recursively

### DIFF
--- a/cmd/hasura-ndc-go/command/internal/connector.go
+++ b/cmd/hasura-ndc-go/command/internal/connector.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"runtime/trace"
+	"slices"
 	"strings"
 
 	"github.com/hasura/ndc-sdk-go/schema"
@@ -221,6 +222,8 @@ func (cg *connectorGenerator) renderOperationHandlers(values []string) string {
 	}
 	var sb strings.Builder
 	sb.WriteRune('{')
+	slices.Sort(values)
+
 	for i, v := range values {
 		if i > 0 {
 			sb.WriteString(", ")
@@ -402,7 +405,7 @@ var enumValues_%s = []%s{%s}
 func Parse%s(input string) (%s, error) {
   result := %s(input)
   if !slices.Contains(enumValues_%s, result) {
-    return %s(""), errors.New("failed to parse %s, expect one of %s")
+    return %s(""), errors.New("failed to parse %s, expect one of [%s]")
   }
 
   return result, nil
@@ -446,7 +449,7 @@ func (s *%s) FromValue(value any) error {
   *s = result
   return nil
 }
-`, pascalName, scalarKey, pascalName, scalarKey, scalarKey, pascalName, scalarKey, scalarKey, strings.Join(enumConstants, ", "),
+`, pascalName, scalarKey, pascalName, scalarKey, scalarKey, pascalName, scalarKey, scalarKey, strings.Join(scalarRep.OneOf, ", "),
 				scalarKey, pascalName, scalarKey, pascalName, scalarKey, pascalName,
 			))
 		default:

--- a/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # build context at repo root: docker build -f Dockerfile .
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/connector-metadata.yaml.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/connector-metadata.yaml.tmpl
@@ -11,6 +11,7 @@ supportedEnvironmentVariables:
     required: false
 commands:
   update: hasura-ndc-go update
+  upgradeConfiguration: hasura-ndc-go update
 cliPlugin:
   name: ndc-go
   version: {{.Version}}

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/functions.go.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/functions.go.tmpl
@@ -1142,7 +1142,7 @@ var enumValues_SomeEnum = []SomeEnum{SomeEnumFoo, SomeEnumBar}
 func ParseSomeEnum(input string) (SomeEnum, error) {
   result := SomeEnum(input)
   if !slices.Contains(enumValues_SomeEnum, result) {
-    return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of SomeEnumFoo, SomeEnumBar")
+    return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of [foo, bar]")
   }
 
   return result, nil

--- a/cmd/hasura-ndc-go/command/internal/testdata/snake_case/expected/functions.go.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/testdata/snake_case/expected/functions.go.tmpl
@@ -836,7 +836,7 @@ var enumValues_SomeEnum = []SomeEnum{SomeEnumFoo, SomeEnumBar}
 func ParseSomeEnum(input string) (SomeEnum, error) {
   result := SomeEnum(input)
   if !slices.Contains(enumValues_SomeEnum, result) {
-    return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of SomeEnumFoo, SomeEnumBar")
+    return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of [foo, bar]")
   }
 
   return result, nil

--- a/example/codegen/types/types.generated.go
+++ b/example/codegen/types/types.generated.go
@@ -130,7 +130,7 @@ var enumValues_SomeEnum = []SomeEnum{SomeEnumFoo, SomeEnumBar}
 func ParseSomeEnum(input string) (SomeEnum, error) {
 	result := SomeEnum(input)
 	if !slices.Contains(enumValues_SomeEnum, result) {
-		return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of SomeEnumFoo, SomeEnumBar")
+		return SomeEnum(""), errors.New("failed to parse SomeEnum, expect one of [foo, bar]")
 	}
 
 	return result, nil


### PR DESCRIPTION
* Fix incorrect error message generation for scalar types.
* Parse files recursively not only the root directories
* Add `upgradeConfiguration` config