### PR TITLE
codegen: support predicate arguments

### DIFF
--- a/cmd/hasura-ndc-go/command/internal/connector_handler.go
+++ b/cmd/hasura-ndc-go/command/internal/connector_handler.go
@@ -27,7 +27,7 @@ func (chb connectorHandlerBuilder) Render() {
 	bs.imports["log/slog"] = ""
 	bs.imports["slices"] = ""
 	bs.imports["github.com/hasura/ndc-sdk-go/connector"] = ""
-	bs.imports["github.com/hasura/ndc-sdk-go/schema"] = ""
+	bs.imports[packageSDKSchema] = ""
 	bs.imports["go.opentelemetry.io/otel/trace"] = ""
 	bs.imports[packageSDKUtils] = ""
 

--- a/cmd/hasura-ndc-go/command/internal/constant.go
+++ b/cmd/hasura-ndc-go/command/internal/constant.go
@@ -154,5 +154,6 @@ var (
 )
 
 const (
-	packageSDKUtils = "github.com/hasura/ndc-sdk-go/utils"
+	packageSDKUtils  = "github.com/hasura/ndc-sdk-go/utils"
+	packageSDKSchema = "github.com/hasura/ndc-sdk-go/schema"
 )

--- a/cmd/hasura-ndc-go/command/internal/schema_parser.go
+++ b/cmd/hasura-ndc-go/command/internal/schema_parser.go
@@ -218,7 +218,7 @@ func (sp *SchemaParser) parsePackageScope(pkg *types.Package, name string) error
 		// ignore 2 first parameters (context and state)
 		if params.Len() == 3 {
 			arg := params.At(2)
-			argumentParser := NewTypeParser(sp, &Field{}, arg.Type(), &opInfo.Kind)
+			argumentParser := NewTypeParser(sp, &Field{}, arg.Type(), NDCTagInfo{}, &opInfo.Kind)
 			argumentInfo, err := argumentParser.ParseArgumentTypes([]string{})
 			if err != nil {
 				return err
@@ -236,7 +236,7 @@ func (sp *SchemaParser) parsePackageScope(pkg *types.Package, name string) error
 			}
 		}
 
-		typeParser := NewTypeParser(sp, &Field{}, resultTuple.At(0).Type(), nil)
+		typeParser := NewTypeParser(sp, &Field{}, resultTuple.At(0).Type(), NDCTagInfo{}, nil)
 		resultType, err := typeParser.Parse([]string{})
 		if err != nil {
 			return err

--- a/cmd/hasura-ndc-go/command/internal/schema_template.go
+++ b/cmd/hasura-ndc-go/command/internal/schema_template.go
@@ -258,6 +258,8 @@ func (rcs RawConnectorSchema) writeType(schemaType schema.Type, depth uint) (str
 		result += fmt.Sprintf("NewNullableType(%s)", nested)
 	case *schema.NamedType:
 		result += fmt.Sprintf(`NewNamedType("%s")`, t.Name)
+	case *schema.PredicateType:
+		result += fmt.Sprintf(`NewPredicateType("%s")`, t.ObjectTypeName)
 	default:
 		return "", fmt.Errorf("invalid schema type: %w", err)
 	}

--- a/cmd/hasura-ndc-go/command/internal/schema_type_parser.go
+++ b/cmd/hasura-ndc-go/command/internal/schema_type_parser.go
@@ -6,9 +6,7 @@ import (
 	"go/types"
 	"strings"
 
-	"github.com/fatih/structtag"
 	"github.com/hasura/ndc-sdk-go/schema"
-	"github.com/rs/zerolog/log"
 )
 
 type TypeParser struct {
@@ -16,15 +14,17 @@ type TypeParser struct {
 	field        *Field
 	rootType     types.Type
 	argumentFor  *OperationKind
+	tagInfo      NDCTagInfo
 	// cached parent named type if the underlying type is an object
 	typeInfo *TypeInfo
 }
 
-func NewTypeParser(schemaParser *SchemaParser, field *Field, ty types.Type, argumentFor *OperationKind) *TypeParser {
+func NewTypeParser(schemaParser *SchemaParser, field *Field, ty types.Type, tagInfo NDCTagInfo, argumentFor *OperationKind) *TypeParser {
 	return &TypeParser{
 		schemaParser: schemaParser,
 		field:        field,
 		rootType:     ty,
+		tagInfo:      tagInfo,
 		argumentFor:  argumentFor,
 	}
 }
@@ -54,18 +54,24 @@ func (tp *TypeParser) parseArgumentTypes(ty types.Type, fieldPaths []string) (*O
 			Fields:       map[string]Field{},
 			SchemaFields: schema.ObjectTypeFields{},
 		}
+
 		if err := tp.parseStructType(result, inferredType, fieldPaths); err != nil {
 			return nil, err
 		}
+
 		return result, nil
 	case *types.Named:
-
 		typeObj := inferredType.Obj()
+		if typeObj == nil {
+			return nil, fmt.Errorf("named type %s does not exist", inferredType.String())
+		}
+
 		typeInfo := &TypeInfo{
 			Name:       typeObj.Name(),
 			SchemaName: typeObj.Name(),
 			TypeAST:    typeObj.Type().Underlying(),
 		}
+
 		pkg := typeObj.Pkg()
 		if pkg != nil {
 			typeInfo.PackagePath = pkg.Path()
@@ -230,6 +236,14 @@ func (tp *TypeParser) parseType(ty types.Type, fieldPaths []string) (Type, error
 			default:
 				return nil, fmt.Errorf("unsupported type %s.%s", innerPkg.Path(), innerType.Name())
 			}
+		case packageSDKSchema:
+			if innerType.Name() == "Expression" && tp.argumentFor != nil {
+				if tp.tagInfo.PredicateObjectName == "" {
+					return nil, fmt.Errorf("%s: predicate field tag must be set `ndc:\"predicate=<object-name>\"`", strings.Join(fieldPaths, "."))
+				}
+
+				return NewNullableType(NewPredicateType(tp.tagInfo.PredicateObjectName)), nil
+			}
 		case "github.com/hasura/ndc-sdk-go/scalar":
 			switch innerType.Name() {
 			case "Date", "BigInt", "Bytes", "URL", "Duration":
@@ -332,19 +346,32 @@ func (tp *TypeParser) parseStructType(objectInfo *ObjectInfo, inferredType *type
 		}
 
 		fieldTag := inferredType.Tag(i)
-		fieldKey, jsonOption := getFieldNameOrTag(fieldVar.Name(), fieldTag)
-		if jsonOption == jsonIgnore {
+
+		tagInfo, err := parseNDCTagInfo(fieldTag)
+		if err != nil {
+			return fmt.Errorf("%s: %w", strings.Join(fieldPaths, "."), err)
+		}
+
+		if tagInfo.Ignored {
 			continue
 		}
+
+		fieldKey := tagInfo.Name
+		if fieldKey == "" {
+			fieldKey = fieldVar.Name()
+		}
+
 		fieldParser := NewTypeParser(tp.schemaParser, &Field{
 			Name:     fieldVar.Name(),
 			Embedded: fieldVar.Embedded(),
 			TypeAST:  fieldVar.Type(),
-		}, fieldVar.Type(), tp.argumentFor)
+		}, fieldVar.Type(), tagInfo, tp.argumentFor)
+
 		field, err := fieldParser.Parse(append(fieldPaths, fieldVar.Name()))
 		if err != nil {
 			return err
 		}
+
 		if field == nil {
 			continue
 		}
@@ -356,9 +383,10 @@ func (tp *TypeParser) parseStructType(objectInfo *ObjectInfo, inferredType *type
 			}
 		} else {
 			fieldSchema := field.Type.Schema()
-			if jsonOption == jsonOmitEmpty && field.Type.Kind() != schema.TypeNullable {
+			if tagInfo.OmitEmpty && field.Type.Kind() != schema.TypeNullable {
 				fieldSchema = schema.NewNullableType(fieldSchema)
 			}
+
 			objectInfo.SchemaFields[fieldKey] = schema.ObjectField{
 				Type: fieldSchema.Encode(),
 			}
@@ -391,8 +419,7 @@ func (tp *TypeParser) parseTypeInfoFromComments(typeInfo *TypeInfo, scope *types
 				text = strings.TrimPrefix(text, typeInfo.Name+" ")
 			}
 
-			enumMatches := ndcEnumCommentRegex.FindStringSubmatch(text)
-
+			enumMatches := ndcEnumCommentRegex.FindStringSubmatch(strings.TrimRight(text, "."))
 			if len(enumMatches) == 2 {
 				rawEnumItems := strings.Split(enumMatches[1], ",")
 				var enums []string
@@ -538,36 +565,4 @@ func parseTypeFromString(input string) (Type, error) {
 	typeInfo.Name = parts[partsLen-1]
 
 	return NewNamedType(typeInfo.Name, typeInfo), nil
-}
-
-const (
-	jsonOmitEmpty = "omitempty"
-	jsonIgnore    = "-"
-)
-
-// Get field name and options by json tag.
-// Return the struct field name if not exist.
-func getFieldNameOrTag(name string, tag string) (string, string) {
-	if tag == "" {
-		return name, ""
-	}
-	tags, err := structtag.Parse(tag)
-	if err != nil {
-		log.Warn().Err(err).Msgf("failed to parse tag of struct field: %s", name)
-		return name, ""
-	}
-
-	jsonTag, err := tags.Get("json")
-	if err != nil {
-		log.Warn().Err(err).Msgf("json tag does not exist in struct field: %s", name)
-		return name, ""
-	}
-	if jsonTag.Value() == "-" {
-		return name, jsonIgnore
-	}
-	nameParts := strings.Split(jsonTag.Value(), ",")
-	if len(nameParts) == 1 {
-		return jsonTag.Name, ""
-	}
-	return nameParts[0], nameParts[1]
 }

--- a/cmd/hasura-ndc-go/command/internal/tag.go
+++ b/cmd/hasura-ndc-go/command/internal/tag.go
@@ -1,0 +1,64 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/structtag"
+)
+
+// NDCTagInfo holds information of an object field that is parsed from the struct tag.
+type NDCTagInfo struct {
+	Name                string
+	Ignored             bool
+	OmitEmpty           bool
+	PredicateObjectName string
+}
+
+// parses connector and json tag information from the raw struct tag.
+func parseNDCTagInfo(input string) (NDCTagInfo, error) {
+	result := NDCTagInfo{}
+	if input == "" {
+		return result, nil
+	}
+
+	tags, err := structtag.Parse(input)
+	if err != nil || tags == nil {
+		return result, err
+	}
+
+	jsonTag, err := tags.Get("json")
+	if err == nil {
+		if jsonTag.Value() == "-" {
+			result.Ignored = true
+		}
+
+		result.Name = strings.TrimSpace(jsonTag.Name)
+		result.OmitEmpty = jsonTag.HasOption("omitempty")
+	}
+
+	rawTag, err := tags.Get("ndc")
+	if err != nil {
+		return result, nil //nolint:nilerr
+	}
+
+	for _, tag := range append(rawTag.Options, rawTag.Name) {
+		keyValue := strings.Split(strings.TrimSpace(tag), "=")
+		if len(keyValue) != 2 {
+			return result, fmt.Errorf("invalid tag: %s", tag)
+		}
+
+		if keyValue[1] == "" {
+			return result, fmt.Errorf("value of %s tag is empty", keyValue[0])
+		}
+
+		switch keyValue[0] {
+		case "predicate":
+			result.PredicateObjectName = keyValue[1]
+		default:
+			return result, fmt.Errorf("invalid tag key: %s", keyValue[0])
+		}
+	}
+
+	return result, nil
+}

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/functions/types.generated.go.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/functions/types.generated.go.tmpl
@@ -826,6 +826,10 @@ func (j *GetTypesArguments) FromValue(input map[string]any) error {
   if err != nil {
     return err
   }
+  j.Where, err = utils.DecodeObjectValueDefault[schema.Expression](input, "where")
+  if err != nil {
+    return err
+  }
   return nil
 }
 // ToMap encodes the struct to a value map
@@ -1103,6 +1107,7 @@ func (j GetTypesArguments) ToMap() map[string]any {
   r["uint_empty"] = j.UintEmpty
   r["url_empty"] = j.URLEmpty
   r["uuid_empty"] = j.UUIDEmpty
+  r["where"] = j.Where
 
   return r
 }

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.go.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.go.tmpl
@@ -696,6 +696,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
           "uuid_empty": schema.ObjectField{
             Type: schema.NewNullableType(schema.NewNamedType("UUID")).Encode(),
           },
+          "where": schema.ObjectField{
+            Type: schema.NewNamedType("JSON").Encode(),
+          },
         },
       },
       "GetTypesArgumentsArrayObject": schema.ObjectType{
@@ -1361,6 +1364,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
           "uuid_empty": {
             Type: schema.NewNullableType(schema.NewNamedType("UUID")).Encode(),
           },
+          "where": {
+            Type: schema.NewNullableType(schema.NewPredicateType("Author")).Encode(),
+          },
         },
       },
       {
@@ -1406,6 +1412,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
         Arguments: map[string]schema.ArgumentInfo{
           "name": {
             Type: schema.NewNamedType("String").Encode(),
+          },
+          "where": {
+            Type: schema.NewNullableType(schema.NewPredicateType("Author")).Encode(),
           },
         },
       },

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.json
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/expected/schema.json
@@ -2,6 +2,25 @@
   "collections": [],
   "functions": [
     {
+      "arguments": {
+        "Limit": {
+          "type": {
+            "name": "Float64",
+            "type": "named"
+          }
+        }
+      },
+      "description": "GetArticles",
+      "name": "getArticles",
+      "result_type": {
+        "element_type": {
+          "name": "GetArticlesResult",
+          "type": "named"
+        },
+        "type": "array"
+      }
+    },
+    {
       "arguments": {},
       "description": "return an scalar boolean",
       "name": "getBool",
@@ -2114,6 +2133,15 @@
               "type": "named"
             }
           }
+        },
+        "where": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "object_type_name": "Author",
+              "type": "predicate"
+            }
+          }
         }
       },
       "name": "getTypes",
@@ -2135,25 +2163,6 @@
           "name": "HelloResult",
           "type": "named"
         }
-      }
-    },
-    {
-      "arguments": {
-        "Limit": {
-          "type": {
-            "name": "Float64",
-            "type": "named"
-          }
-        }
-      },
-      "description": "GetArticles",
-      "name": "getArticles",
-      "result_type": {
-        "element_type": {
-          "name": "GetArticlesResult",
-          "type": "named"
-        },
-        "type": "array"
       }
     }
   ],
@@ -4398,6 +4407,12 @@
               "type": "named"
             }
           }
+        },
+        "where": {
+          "type": {
+            "name": "JSON",
+            "type": "named"
+          }
         }
       }
     },
@@ -4494,38 +4509,19 @@
   "procedures": [
     {
       "arguments": {
-        "author": {
-          "type": {
-            "name": "CreateArticleArgumentsAuthor",
-            "type": "named"
-          }
-        }
-      },
-      "description": "CreateArticle",
-      "name": "create_article",
-      "result_type": {
-        "type": "nullable",
-        "underlying_type": {
-          "name": "CreateArticleResult",
-          "type": "named"
-        }
-      }
-    },
-    {
-      "arguments": {},
-      "description": "Increase",
-      "name": "increase",
-      "result_type": {
-        "name": "Int32",
-        "type": "named"
-      }
-    },
-    {
-      "arguments": {
         "name": {
           "type": {
             "name": "String",
             "type": "named"
+          }
+        },
+        "where": {
+          "type": {
+            "type": "nullable",
+            "underlying_type": {
+              "object_type_name": "Author",
+              "type": "predicate"
+            }
           }
         }
       },
@@ -4559,6 +4555,25 @@
           "type": "named"
         },
         "type": "array"
+      }
+    },
+    {
+      "arguments": {
+        "author": {
+          "type": {
+            "name": "CreateArticleArgumentsAuthor",
+            "type": "named"
+          }
+        }
+      },
+      "description": "CreateArticle",
+      "name": "create_article",
+      "result_type": {
+        "type": "nullable",
+        "underlying_type": {
+          "name": "CreateArticleResult",
+          "type": "named"
+        }
       }
     },
     {
@@ -4598,6 +4613,15 @@
           "name": "CustomHeadersResult_array_nullable_BaseAuthor",
           "type": "named"
         }
+      }
+    },
+    {
+      "arguments": {},
+      "description": "Increase",
+      "name": "increase",
+      "result_type": {
+        "name": "Int32",
+        "type": "named"
       }
     }
   ],

--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/source/functions/prefix.go
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/source/functions/prefix.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hasura/ndc-codegen-test/types"
 	"github.com/hasura/ndc-sdk-go/scalar"
+	"github.com/hasura/ndc-sdk-go/schema"
 )
 
 type Text string
@@ -45,7 +46,8 @@ func FunctionHello(ctx context.Context, state *types.State) (*HelloResult, error
 
 // A create author argument
 type CreateAuthorArguments struct {
-	Name string `json:"name"`
+	Name  string            `json:"name"`
+	Where schema.Expression `json:"where" ndc:"predicate=Author"`
 }
 
 // A create authors argument
@@ -297,7 +299,8 @@ type GetTypesArguments struct {
 	ArrayTimeEmpty       []time.Time        `json:"array_time_empty,omitempty"`
 	ArrayTimePtrEmpty    []*time.Time       `json:"array_time_ptr_empty,omitempty"`
 
-	IgnoredField string `json:"-"`
+	IgnoredField string            `json:"-"`
+	Where        schema.Expression `json:"where" ndc:"predicate=Author"`
 }
 
 func FunctionGetTypes(ctx context.Context, state *types.State, arguments *GetTypesArguments) (*GetTypesArguments, error) {

--- a/cmd/hasura-ndc-go/command/internal/testdata/single_op/expected/schema.json
+++ b/cmd/hasura-ndc-go/command/internal/testdata/single_op/expected/schema.json
@@ -3,17 +3,17 @@
   "functions": [
     {
       "arguments": {},
-      "name": "simpleObject",
+      "name": "hello",
       "result_type": {
-        "name": "SimpleResult",
+        "name": "String",
         "type": "named"
       }
     },
     {
       "arguments": {},
-      "name": "hello",
+      "name": "simpleObject",
       "result_type": {
-        "name": "String",
+        "name": "SimpleResult",
         "type": "named"
       }
     }

--- a/cmd/hasura-ndc-go/command/internal/testdata/snake_case/expected/schema.json
+++ b/cmd/hasura-ndc-go/command/internal/testdata/snake_case/expected/schema.json
@@ -2,6 +2,25 @@
   "collections": [],
   "functions": [
     {
+      "arguments": {
+        "Limit": {
+          "type": {
+            "name": "Float64",
+            "type": "named"
+          }
+        }
+      },
+      "description": "GetArticles",
+      "name": "get_articles",
+      "result_type": {
+        "element_type": {
+          "name": "GetArticlesResult",
+          "type": "named"
+        },
+        "type": "array"
+      }
+    },
+    {
       "arguments": {},
       "description": "return an scalar boolean",
       "name": "get_bool",
@@ -1412,25 +1431,6 @@
           "name": "HelloResult",
           "type": "named"
         }
-      }
-    },
-    {
-      "arguments": {
-        "Limit": {
-          "type": {
-            "name": "Float64",
-            "type": "named"
-          }
-        }
-      },
-      "description": "GetArticles",
-      "name": "get_articles",
-      "result_type": {
-        "element_type": {
-          "name": "GetArticlesResult",
-          "type": "named"
-        },
-        "type": "array"
       }
     }
   ],
@@ -3019,15 +3019,6 @@
       }
     },
     {
-      "arguments": {},
-      "description": "Increase",
-      "name": "increase",
-      "result_type": {
-        "name": "Int32",
-        "type": "named"
-      }
-    },
-    {
       "arguments": {
         "name": {
           "type": {
@@ -3066,6 +3057,15 @@
           "type": "named"
         },
         "type": "array"
+      }
+    },
+    {
+      "arguments": {},
+      "description": "Increase",
+      "name": "increase",
+      "result_type": {
+        "name": "Int32",
+        "type": "named"
       }
     }
   ],

--- a/example/codegen/functions/prefix.go
+++ b/example/codegen/functions/prefix.go
@@ -114,6 +114,7 @@ type GetAuthorArguments struct {
 	*BaseAuthor
 
 	ID string `json:"id"`
+	// Where schema.Expression `json:"where"`
 }
 
 type GetAuthorResult struct {

--- a/example/codegen/functions/prefix.go
+++ b/example/codegen/functions/prefix.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hasura/ndc-codegen-example/types"
 	"github.com/hasura/ndc-codegen-example/types/arguments"
+	"github.com/hasura/ndc-sdk-go/schema"
 	"github.com/hasura/ndc-sdk-go/utils"
 )
 
@@ -50,16 +51,20 @@ func FunctionHello(ctx context.Context, state *types.State) (*HelloResult, error
 // A create author argument
 type CreateAuthorArguments struct {
 	BaseAuthor
+
+	Where schema.Expression `json:"where" ndc:"predicate=Author"`
 }
+
 type CreateAuthorsArguments struct {
 	Authors []CreateAuthorArguments
 }
 
 // A create author result
 type CreateAuthorResult struct {
-	ID        int       `json:"id"`
-	Name      string    `json:"name"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        int               `json:"id"`
+	Name      string            `json:"name"`
+	CreatedAt time.Time         `json:"created_at"`
+	Where     schema.Expression `json:"where"`
 }
 
 // ProcedureCreateAuthor creates an author
@@ -70,8 +75,9 @@ func ProcedureCreateAuthor(ctx context.Context, state *types.State, arguments *C
 	}
 
 	return &CreateAuthorResult{
-		ID:   1,
-		Name: arguments.Name,
+		ID:    1,
+		Name:  arguments.Name,
+		Where: arguments.Where,
 	}, nil
 }
 
@@ -113,14 +119,15 @@ type BaseAuthor struct {
 type GetAuthorArguments struct {
 	*BaseAuthor
 
-	ID string `json:"id"`
-	// Where schema.Expression `json:"where"`
+	ID    string            `json:"id"`
+	Where schema.Expression `json:"where" ndc:"predicate=Author"`
 }
 
 type GetAuthorResult struct {
 	*CreateAuthorResult
 
-	Disabled bool `json:"disabled"`
+	Where    schema.Expression `json:"where"`
+	Disabled bool              `json:"disabled"`
 }
 
 func FunctionGetAuthor(ctx context.Context, state *types.State, arguments *GetAuthorArguments) (*GetAuthorResult, error) {
@@ -129,6 +136,7 @@ func FunctionGetAuthor(ctx context.Context, state *types.State, arguments *GetAu
 			ID:   1,
 			Name: arguments.Name,
 		},
+		Where:    arguments.Where,
 		Disabled: false,
 	}, nil
 }

--- a/example/codegen/functions/types.generated.go
+++ b/example/codegen/functions/types.generated.go
@@ -53,6 +53,10 @@ func (j *GetAuthorArguments) FromValue(input map[string]any) error {
 	if err != nil {
 		return err
 	}
+	j.Where, err = utils.DecodeObjectValueDefault[schema.Expression](input, "where")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -81,6 +85,9 @@ func (j CreateArticleResult) ToMap() map[string]any {
 func (j CreateAuthorArguments) ToMap() map[string]any {
 	r := make(map[string]any)
 	r = utils.MergeMap(r, j.BaseAuthor.ToMap())
+	if j.Where != nil {
+		r["where"] = j.Where
+	}
 
 	return r
 }
@@ -91,6 +98,7 @@ func (j CreateAuthorResult) ToMap() map[string]any {
 	r["created_at"] = j.CreatedAt
 	r["id"] = j.ID
 	r["name"] = j.Name
+	r["where"] = j.Where
 
 	return r
 }
@@ -111,6 +119,7 @@ func (j GetAuthorResult) ToMap() map[string]any {
 		r = utils.MergeMap(r, (*j.CreateAuthorResult).ToMap())
 	}
 	r["disabled"] = j.Disabled
+	r["where"] = j.Where
 
 	return r
 }

--- a/example/codegen/go.mod
+++ b/example/codegen/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
-	github.com/hasura/ndc-sdk-go v1.6.4
+	github.com/hasura/ndc-sdk-go v1.7.0
 	go.opentelemetry.io/otel v1.29.0
 	go.opentelemetry.io/otel/trace v1.29.0
 	golang.org/x/sync v0.10.0

--- a/example/codegen/schema.generated.go
+++ b/example/codegen/schema.generated.go
@@ -65,6 +65,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					"name": schema.ObjectField{
 						Type: schema.NewNamedType("String").Encode(),
 					},
+					"where": schema.ObjectField{
+						Type: schema.NewNullableType(schema.NewPredicateType("Author")).Encode(),
+					},
 				},
 			},
 			"CreateAuthorResult": schema.ObjectType{
@@ -77,6 +80,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"name": schema.ObjectField{
 						Type: schema.NewNamedType("String").Encode(),
+					},
+					"where": schema.ObjectField{
+						Type: schema.NewNamedType("JSON").Encode(),
 					},
 				},
 			},
@@ -123,6 +129,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"name": schema.ObjectField{
 						Type: schema.NewNamedType("String").Encode(),
+					},
+					"where": schema.ObjectField{
+						Type: schema.NewNamedType("JSON").Encode(),
 					},
 				},
 			},
@@ -841,6 +850,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					"name": {
 						Type: schema.NewNamedType("String").Encode(),
 					},
+					"where": {
+						Type: schema.NewNullableType(schema.NewPredicateType("Author")).Encode(),
+					},
 				},
 			},
 			{
@@ -852,6 +864,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 					},
 					"name": {
 						Type: schema.NewNamedType("String").Encode(),
+					},
+					"where": {
+						Type: schema.NewNullableType(schema.NewPredicateType("Author")).Encode(),
 					},
 				},
 			},
@@ -1556,6 +1571,9 @@ func GetConnectorSchema() *schema.SchemaResponse {
 				Arguments: map[string]schema.ArgumentInfo{
 					"name": {
 						Type: schema.NewNamedType("String").Encode(),
+					},
+					"where": {
+						Type: schema.NewNullableType(schema.NewPredicateType("Author")).Encode(),
 					},
 				},
 			},

--- a/example/codegen/testdata/mutation/createAuthor/expected.json
+++ b/example/codegen/testdata/mutation/createAuthor/expected.json
@@ -4,7 +4,36 @@
       "result": {
         "created_at": "0001-01-01T00:00:00Z",
         "id": 1,
-        "name": "q2Ia7pg5VL"
+        "name": "q2Ia7pg5VL",
+        "where": {
+          "expressions": [
+            {
+              "column": {
+                "name": "name",
+                "type": "column"
+              },
+              "operator": "_eq",
+              "type": "binary_comparison_operator",
+              "value": {
+                "type": "scalar",
+                "value": "hello"
+              }
+            },
+            {
+              "column": {
+                "name": "id",
+                "type": "column"
+              },
+              "operator": "_eq",
+              "type": "binary_comparison_operator",
+              "value": {
+                "type": "scalar",
+                "value": "1"
+              }
+            }
+          ],
+          "type": "and"
+        }
       },
       "type": "procedure"
     }

--- a/example/codegen/testdata/mutation/createAuthor/request.json
+++ b/example/codegen/testdata/mutation/createAuthor/request.json
@@ -5,7 +5,36 @@
       "type": "procedure",
       "name": "createAuthor",
       "arguments": {
-        "name": "q2Ia7pg5VL"
+        "name": "q2Ia7pg5VL",
+        "where": {
+          "expressions": [
+            {
+              "column": {
+                "name": "name",
+                "type": "column"
+              },
+              "operator": "_eq",
+              "type": "binary_comparison_operator",
+              "value": {
+                "type": "scalar",
+                "value": "hello"
+              }
+            },
+            {
+              "column": {
+                "name": "id",
+                "type": "column"
+              },
+              "operator": "_eq",
+              "type": "binary_comparison_operator",
+              "value": {
+                "type": "scalar",
+                "value": "1"
+              }
+            }
+          ],
+          "type": "and"
+        }
       },
       "fields": {
         "fields": {
@@ -19,6 +48,10 @@
           },
           "name": {
             "column": "name",
+            "type": "column"
+          },
+          "where": {
+            "column": "where",
             "type": "column"
           }
         },

--- a/example/codegen/testdata/query/getAuthor/expected.json
+++ b/example/codegen/testdata/query/getAuthor/expected.json
@@ -4,7 +4,36 @@
       {
         "__value": {
           "id": 1,
-          "name": "3uPAoDW2BB"
+          "name": "3uPAoDW2BB",
+          "where": {
+            "expressions": [
+              {
+                "column": {
+                  "name": "name",
+                  "type": "column"
+                },
+                "operator": "_eq",
+                "type": "binary_comparison_operator",
+                "value": {
+                  "type": "scalar",
+                  "value": "hello"
+                }
+              },
+              {
+                "column": {
+                  "name": "id",
+                  "type": "column"
+                },
+                "operator": "_eq",
+                "type": "binary_comparison_operator",
+                "value": {
+                  "type": "scalar",
+                  "value": "1"
+                }
+              }
+            ],
+            "type": "and"
+          }
         }
       }
     ]

--- a/example/codegen/testdata/query/getAuthor/request.json
+++ b/example/codegen/testdata/query/getAuthor/request.json
@@ -7,6 +7,26 @@
     "name": {
       "type": "literal",
       "value": "3uPAoDW2BB"
+    },
+    "where": {
+      "type": "literal",
+      "value": {
+        "type": "and",
+        "expressions": [
+          {
+            "type": "binary_comparison_operator",
+            "column": { "type": "column", "name": "name", "path": [] },
+            "operator": "_eq",
+            "value": { "type": "scalar", "value": "hello" }
+          },
+          {
+            "type": "binary_comparison_operator",
+            "column": { "type": "column", "name": "id", "path": [] },
+            "operator": "_eq",
+            "value": { "type": "scalar", "value": "1" }
+          }
+        ]
+      }
     }
   },
   "collection": "getAuthor",
@@ -23,6 +43,10 @@
             },
             "name": {
               "column": "name",
+              "type": "column"
+            },
+            "where": {
+              "column": "where",
               "type": "column"
             }
           },

--- a/example/reference/connector.go
+++ b/example/reference/connector.go
@@ -1338,7 +1338,12 @@ func evalExpression(
 	root map[string]any,
 	item map[string]any,
 ) (bool, error) {
-	switch expression := expr.Interface().(type) {
+	exprT, err := expr.InterfaceT()
+	if err != nil {
+		return false, err
+	}
+
+	switch expression := exprT.(type) {
 	case *schema.ExpressionAnd:
 		for _, exp := range expression.Expressions {
 			ok, err := evalExpression(collectionRelationships, variables, state, exp, root, item)

--- a/schema/extend.go
+++ b/schema/extend.go
@@ -1654,7 +1654,7 @@ func (j *Expression) FromValue(input map[string]any) error {
 			return fmt.Errorf("field expressions in Expression: expected array, got %v", rawExpressions)
 		}
 
-		var expressions []Expression
+		expressions := []Expression{}
 		for i, rawItem := range rawExpressionsArray {
 			if rawItem == nil {
 				continue
@@ -1814,7 +1814,9 @@ func (j Expression) AsAnd() (*ExpressionAnd, error) {
 	}
 	expressions, ok := rawExpressions.([]Expression)
 	if !ok {
-		return nil, fmt.Errorf("invalid ExpressionAnd.expression type; expected: []Expression, got: %+v", rawExpressions)
+		if err := mapstructure.Decode(rawExpressions, &expressions); err != nil {
+			return nil, fmt.Errorf("invalid ExpressionAnd.expression type; expected: []Expression, got: %v", rawExpressions)
+		}
 	}
 
 	return &ExpressionAnd{
@@ -1829,6 +1831,7 @@ func (j Expression) AsOr() (*ExpressionOr, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if t != ExpressionTypeOr {
 		return nil, fmt.Errorf("invalid Expression type; expected: %s, got: %s", ExpressionTypeOr, t)
 	}
@@ -1837,9 +1840,12 @@ func (j Expression) AsOr() (*ExpressionOr, error) {
 	if !ok {
 		return nil, errors.New("ExpressionOr.expression is required")
 	}
+
 	expressions, ok := rawExpressions.([]Expression)
 	if !ok {
-		return nil, fmt.Errorf("invalid ExpressionOr.expression type; expected: []Expression, got: %+v", rawExpressions)
+		if err := mapstructure.Decode(rawExpressions, &expressions); err != nil {
+			return nil, fmt.Errorf("invalid ExpressionOr.expression type; expected: []Expression, got: %v", rawExpressions)
+		}
 	}
 
 	return &ExpressionOr{
@@ -1862,9 +1868,12 @@ func (j Expression) AsNot() (*ExpressionNot, error) {
 	if !ok {
 		return nil, errors.New("ExpressionNot.expression is required")
 	}
+
 	expression, ok := rawExpression.(Expression)
 	if !ok {
-		return nil, fmt.Errorf("invalid ExpressionNot.expression type; expected: Expression, got: %+v", rawExpression)
+		if err := mapstructure.Decode(rawExpression, &expression); err != nil {
+			return nil, fmt.Errorf("invalid ExpressionNot.expression type; expected: Expression, got: %+v", rawExpression)
+		}
 	}
 
 	return &ExpressionNot{
@@ -1879,6 +1888,7 @@ func (j Expression) AsUnaryComparisonOperator() (*ExpressionUnaryComparisonOpera
 	if err != nil {
 		return nil, err
 	}
+
 	if t != ExpressionTypeUnaryComparisonOperator {
 		return nil, fmt.Errorf("invalid Expression type; expected: %s, got: %s", ExpressionTypeUnaryComparisonOperator, t)
 	}
@@ -1887,6 +1897,7 @@ func (j Expression) AsUnaryComparisonOperator() (*ExpressionUnaryComparisonOpera
 	if !ok {
 		return nil, errors.New("ExpressionUnaryComparisonOperator.operator is required")
 	}
+
 	operator, ok := rawOperator.(UnaryComparisonOperator)
 	if !ok {
 		operatorStr, ok := rawOperator.(string)
@@ -1901,6 +1912,7 @@ func (j Expression) AsUnaryComparisonOperator() (*ExpressionUnaryComparisonOpera
 	if !ok {
 		return nil, errors.New("ExpressionUnaryComparisonOperator.column is required")
 	}
+
 	column, ok := rawColumn.(ComparisonTarget)
 	if !ok {
 		return nil, fmt.Errorf("invalid ExpressionUnaryComparisonOperator.column type; expected: ComparisonTarget, got: %v", rawColumn)
@@ -2000,6 +2012,7 @@ func (j Expression) InterfaceT() (ExpressionEncoder, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	switch t {
 	case ExpressionTypeAnd:
 		return j.AsAnd()

--- a/schema/type.go
+++ b/schema/type.go
@@ -169,12 +169,19 @@ func (ty Type) AsNamed() (*NamedType, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if t != TypeNamed {
 		return nil, fmt.Errorf("invalid Type type; expected %s, got %s", TypeNamed, t)
 	}
+
+	name, err := getStringValueByKey(ty, "name")
+	if err != nil {
+		return nil, fmt.Errorf("name in NamedType: %w", err)
+	}
+
 	return &NamedType{
 		Type: t,
-		Name: getStringValueByKey(ty, "name"),
+		Name: name,
 	}, nil
 }
 
@@ -236,9 +243,14 @@ func (ty Type) AsPredicate() (*PredicateType, error) {
 		return nil, fmt.Errorf("invalid Type type; expected %s, got %s", TypePredicate, t)
 	}
 
+	name, err := getStringValueByKey(ty, "object_type_name")
+	if err != nil {
+		return nil, fmt.Errorf("object_type_name in PredicateType: %w", err)
+	}
+
 	return &PredicateType{
 		Type:           t,
-		ObjectTypeName: getStringValueByKey(ty, "object_type_name"),
+		ObjectTypeName: name,
 	}, nil
 }
 

--- a/schema/utils.go
+++ b/schema/utils.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 )
 
@@ -19,21 +20,29 @@ func isNullJSON(value []byte) bool {
 	return len(value) == 0 || string(value) == "null"
 }
 
-func getStringValueByKey(collection map[string]any, key string) string {
+func getStringValueByKey(collection map[string]any, key string) (string, error) {
 	if len(collection) == 0 {
-		return ""
+		return "", nil
 	}
 
 	anyValue, ok := collection[key]
-	if !ok || isNil(anyValue) {
-		return ""
+	if !ok || anyValue == nil {
+		return "", nil
 	}
 
 	if arg, ok := anyValue.(string); ok {
-		return arg
+		return arg, nil
 	}
 
-	return ""
+	if arg, ok := anyValue.(*string); ok {
+		if arg == nil {
+			return "", nil
+		}
+
+		return *arg, nil
+	}
+
+	return "", fmt.Errorf("expected string, got %v", anyValue)
 }
 
 func unmarshalStringFromJsonMap(collection map[string]json.RawMessage, key string, required bool) (string, error) {

--- a/utils/environment.go
+++ b/utils/environment.go
@@ -16,8 +16,8 @@ var (
 
 // EnvString represents either a literal string or an environment reference
 type EnvString struct {
-	Value    *string `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    *string `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvString creates an EnvString instance
@@ -101,8 +101,8 @@ func (ev EnvString) GetOrDefault(defaultValue string) (string, error) {
 
 // EnvInt represents either a literal integer or an environment reference
 type EnvInt struct {
-	Value    *int64  `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    *int64  `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvInt creates an EnvInt instance.
@@ -175,8 +175,8 @@ func (ev EnvInt) GetOrDefault(defaultValue int64) (int64, error) {
 
 // EnvBool represents either a literal boolean or an environment reference
 type EnvBool struct {
-	Value    *bool   `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    *bool   `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvBool creates an EnvBool instance.
@@ -249,8 +249,8 @@ func (ev EnvBool) GetOrDefault(defaultValue bool) (bool, error) {
 
 // EnvFloat represents either a literal floating point number or an environment reference
 type EnvFloat struct {
-	Value    *float64 `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string  `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    *float64 `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string  `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvFloat creates an EnvFloat instance.
@@ -342,8 +342,8 @@ func validateEnvironmentMapValue(variable *string) error {
 
 // EnvMapString represents either a literal string map or an environment reference
 type EnvMapString struct {
-	Value    map[string]string `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string           `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    map[string]string `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string           `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvMapString creates an EnvMapString instance.
@@ -399,8 +399,8 @@ func (ev EnvMapString) Get() (map[string]string, error) {
 
 // EnvMapInt represents either a literal int map or an environment reference
 type EnvMapInt struct {
-	Value    map[string]int64 `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string          `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    map[string]int64 `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string          `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvMapInt creates an EnvMapInt instance.
@@ -456,8 +456,8 @@ func (ev EnvMapInt) Get() (map[string]int64, error) {
 
 // EnvMapFloat represents either a literal float map or an environment reference
 type EnvMapFloat struct {
-	Value    map[string]float64 `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string            `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    map[string]float64 `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string            `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvMapFloat creates an EnvMapFloat instance.
@@ -513,8 +513,8 @@ func (ev EnvMapFloat) Get() (map[string]float64, error) {
 
 // EnvMapBool represents either a literal bool map or an environment reference
 type EnvMapBool struct {
-	Value    map[string]bool `json:"value,omitempty" yaml:"value,omitempty" jsonschema:"anyof_required=value"`
-	Variable *string         `json:"env,omitempty" yaml:"env,omitempty" jsonschema:"anyof_required=env"`
+	Value    map[string]bool `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value" jsonschema:"anyof_required=value"`
+	Variable *string         `json:"env,omitempty" yaml:"env,omitempty" mapstructure:"env" jsonschema:"anyof_required=env"`
 }
 
 // NewEnvMapBool creates an EnvMapBool instance.


### PR DESCRIPTION
Add the `ndc` struct tag to support predicate arguments. If there is a `schema.Expression` field with `ndc:"predicate=<object-name>"` tag in the argument struct it will be generated as a Predicate type. 

```go
type CreateAuthorArguments struct {
	Where schema.Expression `json:"where" ndc:"predicate=Author"`
}
```

```json
{
  "arguments": {
    "where": {
      "type": {
        "type": "nullable",
        "underlying_type": {
          "object_type_name": "Author",
          "type": "predicate"
        }
      }
    }
  },
  "name": "createAuthor",
  "result_type": {
    "type": "nullable",
    "underlying_type": {
      "name": "CreateAuthorResult",
      "type": "named"
    }
  }
}
```