### PR TITLE
fix: lazily initialize the credentials client

### DIFF
--- a/credentials/credentials_provider.go
+++ b/credentials/credentials_provider.go
@@ -19,7 +19,9 @@ import (
 
 var errAuthWebhookUriRequired = errors.New("the env var HASURA_CREDENTIALS_PROVIDER_URI must be set and non-empty")
 
-var defaultClient, _ = NewCredentialClient(http.DefaultClient)
+var defaultClient = CredentialClient{
+	httpClient: http.DefaultClient,
+}
 
 var tracer = otel.Tracer("CredentialProvider")
 


### PR DESCRIPTION
Lazily initialize the credentials client so the propagator can load the correct propagations from the connector.