### PR TITLE
return only the credentials property from the credential provider response

### DIFF
--- a/credentials/credentials_provider.go
+++ b/credentials/credentials_provider.go
@@ -18,8 +18,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var errAuthWebhookUriRequired = errors.New("the env var HASURA_CREDENTIALS_PROVIDER_URI must be set and non-empty")
-var errEmptyCredentials = errors.New("empty credentials")
+var (
+	errAuthWebhookUriRequired = errors.New("the env var HASURA_CREDENTIALS_PROVIDER_URI must be set and non-empty")
+	errEmptyCredentials       = errors.New("empty credentials")
+)
 
 var defaultClient = CredentialClient{
 	httpClient: http.DefaultClient,

--- a/credentials/credentials_provider.go
+++ b/credentials/credentials_provider.go
@@ -138,7 +138,6 @@ func (cc *CredentialClient) AcquireCredentials(ctx context.Context, key string, 
 
 	var payload Payload
 	err = json.NewDecoder(resp.Body).Decode(&payload)
-
 	if err != nil {
 		span.SetStatus(codes.Error, "failed to read the response")
 		span.RecordError(err)

--- a/credentials/credentials_provider_test.go
+++ b/credentials/credentials_provider_test.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
+
+	"go.opentelemetry.io/otel"
 )
 
 func TestAcquireCredentials(t *testing.T) {
@@ -36,7 +39,7 @@ func TestAcquireCredentials(t *testing.T) {
 					t.Errorf("expected Authorization=Bearer %s; got %s", bearerToken, r.Header.Get("Authorization"))
 				}
 
-				fmt.Fprint(w, "credentials")
+				fmt.Fprint(w, "{ \"credentials\": \"api-key\" }")
 			}))
 
 			defer server.Close()
@@ -44,18 +47,20 @@ func TestAcquireCredentials(t *testing.T) {
 			// Set the environment variable
 			os.Setenv("HASURA_CREDENTIALS_PROVIDER_URI", server.URL)
 			os.Setenv("HASURA_CREDENTIALS_PROVIDER_BEARER_TOKEN", bearerToken)
+			defer os.Unsetenv("HASURA_CREDENTIALS_PROVIDER_URI")
+			defer os.Unsetenv("HASURA_CREDENTIALS_PROVIDER_BEARER_TOKEN")
 
 			credentials, err := AcquireCredentials(context.TODO(), "key", false)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			if credentials != "credentials" {
-				t.Errorf("expected credentials to be 'credentials', got '%s'", credentials)
+			if credentials != "api-key" {
+				t.Errorf("expected credentials to be 'api-key', got '%s'", credentials)
 			}
 		})
 
-		t.Run("when the request fails", func(t *testing.T) {
+		t.Run("when the server does not exist", func(t *testing.T) {
 			os.Setenv("HASURA_CREDENTIALS_PROVIDER_URI", "http://localhost:0000")
 
 			_, err := AcquireCredentials(context.TODO(), "key", false)
@@ -63,5 +68,29 @@ func TestAcquireCredentials(t *testing.T) {
 				t.Error("expected an error, got nil")
 			}
 		})
+	})
+
+	t.Run("when the response does not have credentials", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "{}")
+		}))
+
+		defer server.Close()
+
+		serverUri, err := url.Parse(server.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		client := &CredentialClient{
+			providerUri: serverUri,
+			httpClient:  server.Client(),
+			propagator:  otel.GetTextMapPropagator(),
+		}
+
+		_, err = client.AcquireCredentials(context.TODO(), "key", false)
+		if err != errEmptyCredentials {
+			t.Errorf("expected an empty credentails error, got: %s\n", err)
+		}
 	})
 }

--- a/utils/decode_test.go
+++ b/utils/decode_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -217,7 +218,7 @@ func TestDecodeDateTime(t *testing.T) {
 		iNow := float64(now.UnixNano()) / float64(1000)
 		value, err := DecodeDateTime(iNow, WithBaseUnix(time.Microsecond))
 		assert.NilError(t, err)
-		assert.Equal(t, int64(now.UnixNano()/1000), int64(value.UnixNano()/1000))
+		assert.Assert(t, math.Abs(float64(int64(now.UnixNano()/1000)-int64(value.UnixNano()/1000))) <= 1)
 	})
 
 	t.Run("from_string", func(t *testing.T) {


### PR DESCRIPTION
According to the [Credentials Provider RFC](https://docs.google.com/document/d/1auGoIR7_5sPSVAAsxyKcdK_bgQZeT3Uxm0CwPRrE1yY/edit?tab=t.0), the function should:
> Return the value of the `credentials` property on the returned json object

This PR fixes the response of the function to only return the value of the `credentials` property