### PR TITLE
fix: tagalign lint error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,8 @@ linters:
       # Minimal code complexity to report.
       # Default: 30 (but we recommend 10-20)
       min-complexity: 31
+    tagalign:
+      sort: false
 
   # Defines a set of rules to ignore issues.
   # It does not skip the analysis, and so does not ignore "typecheck" errors.


### PR DESCRIPTION
Disable the sort setting of tagalign. This rule is error prone