### PR TITLE
Marshal nil foreign_keys as empty object by default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,7 @@ linters:
       # Default: 30 (but we recommend 10-20)
       min-complexity: 31
     tagalign:
-      sort: false
+      strict: false
 
   # Defines a set of rules to ignore issues.
   # It does not skip the analysis, and so does not ignore "typecheck" errors.

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ go-tidy:
 .PHONY: lint
 lint:
 	golangci-lint run --fix
-	cd cmd/hasura-ndc-go && golangci-lint run --fix
+	cd cmd/hasura-ndc-go && golangci-lint run --fix --config ../../.golangci.yml
 	
 # clean the output directory and generated tests snapshots
 .PHONY: clean

--- a/example/reference/schema.go
+++ b/example/reference/schema.go
@@ -208,7 +208,6 @@ var ndcSchema = schema.SchemaResponse{
 					Type:        schema.NewNamedType("String").Encode(),
 				},
 			},
-			ForeignKeys: schema.ObjectTypeForeignKeys{},
 		},
 		"country": {
 			Description: utils.ToPtr("A country"),

--- a/schema/query.go
+++ b/schema/query.go
@@ -47,64 +47,6 @@ func (j Group) ToMap() map[string]any {
 	return result
 }
 
-// UnmarshalJSONMap decodes FunctionInfo from a JSON map.
-func (j *FunctionInfo) UnmarshalJSONMap(raw map[string]json.RawMessage) error {
-	rawArguments, ok := raw["arguments"]
-
-	var arguments FunctionInfoArguments
-
-	if ok && !isNullJSON(rawArguments) {
-		if err := json.Unmarshal(rawArguments, &arguments); err != nil {
-			return fmt.Errorf("FunctionInfo.arguments: %w", err)
-		}
-	}
-
-	rawName, ok := raw["name"]
-	if !ok || isNullJSON(rawName) {
-		return errors.New("FunctionInfo.name: required")
-	}
-
-	var name string
-
-	if err := json.Unmarshal(rawName, &name); err != nil {
-		return fmt.Errorf("FunctionInfo.name: %w", err)
-	}
-
-	if name == "" {
-		return errors.New("FunctionInfo.name: required")
-	}
-
-	rawDescription, ok := raw["description"]
-
-	var description *string
-
-	if ok && !isNullJSON(rawDescription) {
-		if err := json.Unmarshal(rawDescription, &description); err != nil {
-			return fmt.Errorf("FunctionInfo.description: %w", err)
-		}
-	}
-
-	rawResultType, ok := raw["result_type"]
-	if !ok || isNullJSON(rawResultType) {
-		return errors.New("FunctionInfo.result_type: required")
-	}
-
-	var resultType Type
-
-	if err := json.Unmarshal(rawResultType, &resultType); err != nil {
-		return fmt.Errorf("FunctionInfo.result_type: %w", err)
-	}
-
-	*j = FunctionInfo{
-		Arguments:   arguments,
-		Name:        name,
-		ResultType:  resultType,
-		Description: description,
-	}
-
-	return nil
-}
-
 // FromValue decodes the raw object value to the instance.
 func (pe *PathElement) FromValue(raw map[string]any) error {
 	arguments, err := getRelationshipArgumentMapByKey(raw, "arguments")


### PR DESCRIPTION
Marshal the `foreign_keys` field in ObjectType as an empty object by default.