### PR TITLE
feat: HASURA_SERVER_MAX_BODY_MEGABYTES and HASURA_SERVER_DEFAULT_HTTP_ERROR_STATUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,19 +139,19 @@ The prefix is empty by default. You can set the prefix for your connector by `Wi
 
 ### Logging
 
-NDC Go SDK uses the standard [log/slog](https://pkg.go.dev/log/slog) that provides highly customizable and structured logging. By default, the logger is printed in JSON format and configurable level with `--log-level` (HASURA_LOG_LEVEL) flag. You also can replace it with different logging libraries that can wrap the `slog.Handler` interface, and set the logger with the `WithLogger` or `WithLoggerFunc` option.
+NDC Go SDK uses the standard [log/slog](https://pkg.go.dev/log/slog) that provides highly customizable and structured logging. By default, the logger is printed in JSON format and configurable level with `--log-level` (HASURA_LOG_LEVEL) flag. You can also replace it with different logging libraries that can wrap the `slog.Handler` interface, and set the logger with the `WithLogger` or `WithLoggerFunc` option.
 
 ## Best Practices 
 
 ### Error Handling
 
-You should wraps exception errors with the `ConnectorError` struct and specify the explicit HTTP error status. `HASURA_SERVER_DEFAULT_HTTP_ERROR_STATUS` (default to `422`) will be returned if you don't wrap the error. The connector supports helper functions to create connector errors in the [schema](./schema/error.go) package.
+You should wrap exception errors with the `ConnectorError` struct and specify the explicit HTTP error status. `HASURA_SERVER_DEFAULT_HTTP_ERROR_STATUS` (default to `422`) will be returned if you don't wrap the error. The connector supports helper functions to create connector errors in the [schema](./schema/error.go) package.
 
-The Hasura engine v3 shows the explicit error content only if the connector returns HTTP 422 Unprocessable Content. Otherwise, the general internal error is responded. Therefore, you should actively control which error is safe to show it to end users.
+The Hasura engine v3 shows the explicit error content only if the connector returns HTTP 422 Unprocessable Content. Otherwise, the general internal error is responded to. Therefore, you should actively control which error is safe to show it to end users.
 
 ## Customize the CLI
 
-The SDK uses [Kong](https://github.com/alecthomas/kong), a lightweight command-line parser to implement the CLI interface.
+The SDK uses [Kong](https://github.com/alecthomas/kong), a lightweight command-line parser, to implement the CLI interface.
 
 The default CLI already implements the `serve` command, so you don't need to do anything. However, it's also easy to extend if you want to add more custom commands.
 

--- a/README.md
+++ b/README.md
@@ -58,42 +58,46 @@ Flags:
   -h, --help                                   Show context-sensitive help.
       --log-level="info"                       Log level ($HASURA_LOG_LEVEL).
 
-      --service-name=STRING                    OpenTelemetry service name ($OTEL_SERVICE_NAME).
-      --otlp-endpoint=STRING                   OpenTelemetry receiver endpoint that is set as default for all types ($OTEL_EXPORTER_OTLP_ENDPOINT).
-      --otlp-traces-endpoint=STRING            OpenTelemetry endpoint for traces ($OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).
-      --otlp-metrics-endpoint=STRING           OpenTelemetry endpoint for metrics ($OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).
-      --otlp-logs-endpoint=STRING              OpenTelemetry endpoint for logs ($OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).
-      --otlp-insecure                          Disable LTS for OpenTelemetry exporters ($OTEL_EXPORTER_OTLP_INSECURE).
-      --otlp-traces-insecure                   Disable LTS for OpenTelemetry traces exporter ($OTEL_EXPORTER_OTLP_TRACES_INSECURE).
-      --otlp-metrics-insecure                  Disable LTS for OpenTelemetry metrics exporter ($OTEL_EXPORTER_OTLP_METRICS_INSECURE).
-      --otlp-logs-insecure                     Disable LTS for OpenTelemetry logs exporter ($OTEL_EXPORTER_OTLP_LOGS_INSECURE).
-      --otlp-protocol=STRING                   OpenTelemetry receiver protocol for all types ($OTEL_EXPORTER_OTLP_PROTOCOL).
-      --otlp-traces-protocol=STRING            OpenTelemetry receiver protocol for traces ($OTEL_EXPORTER_OTLP_TRACES_PROTOCOL).
-      --otlp-metrics-protocol=STRING           OpenTelemetry receiver protocol for metrics ($OTEL_EXPORTER_OTLP_METRICS_PROTOCOL).
-      --otlp-logs-protocol=STRING              OpenTelemetry receiver protocol for logs ($OTEL_EXPORTER_OTLP_LOGS_PROTOCOL).
-      --otlp-compression="gzip"                Enable compression for OTLP exporters. Accept: none, gzip ($OTEL_EXPORTER_OTLP_COMPRESSION)
-      --otlp-trace-compression="gzip"          Enable compression for OTLP traces exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_TRACES_COMPRESSION)
-      --otlp-metrics-compression="gzip"        Enable compression for OTLP metrics exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_METRICS_COMPRESSION)
-      --otlp-logs-compression="gzip"           Enable compression for OTLP logs exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_LOGS_COMPRESSION)
-      --metrics-exporter="none"                Metrics export type. Accept: none, otlp, prometheus ($OTEL_METRICS_EXPORTER)
-      --logs-exporter="none"                   Logs export type. Accept: none, otlp ($OTEL_LOGS_EXPORTER)
-      --prometheus-port=PROMETHEUS-PORT        Prometheus port for the Prometheus HTTP server. Use /metrics endpoint of the connector server if empty
-                                               ($OTEL_EXPORTER_PROMETHEUS_PORT)
-      --disable-go-metrics                     Disable internal Go and process metrics
-      --server-read-timeout=DURATION           Maximum duration for reading the entire request, including the body. A zero or negative value means there will be no timeout
-                                               ($HASURA_SERVER_READ_TIMEOUT)
-      --server-read-header-timeout=DURATION    Amount of time allowed to read request headers. If zero, the value of ReadTimeout is used ($HASURA_SERVER_READ_HEADER_TIMEOUT)
-      --server-write-timeout=DURATION          Maximum duration before timing out writes of the response. A zero or negative value means there will be no timeout
-                                               ($HASURA_SERVER_WRITE_TIMEOUT)
-      --server-idle-timeout=DURATION           Maximum amount of time to wait for the next request when keep-alives are enabled. If zero, the value of ReadTimeout is used
-                                               ($HASURA_SERVER_IDLE_TIMEOUT)
-      --server-max-header-kilobytes=1024       Maximum number of kilobytes the server will read parsing the request header's keys and values, including the request line
-                                               ($HASURA_SERVER_MAX_HEADER_KILOBYTES)
-      --server-tls-cert-file=STRING            Path of the TLS certificate file ($HASURA_SERVER_TLS_CERT_FILE)
-      --server-tls-key-file=STRING             Path of the TLS key file ($HASURA_SERVER_TLS_KEY_FILE)
-      --configuration=STRING                   Configuration directory ($HASURA_CONFIGURATION_DIRECTORY)
-      --port=8080                              Serve Port ($HASURA_CONNECTOR_PORT)
-      --service-token-secret=STRING            Service token secret ($HASURA_SERVICE_TOKEN_SECRET)
+      --service-name=STRING                     OpenTelemetry service name ($OTEL_SERVICE_NAME).
+      --otlp-endpoint=STRING                    OpenTelemetry receiver endpoint that is set as default for all types ($OTEL_EXPORTER_OTLP_ENDPOINT).
+      --otlp-traces-endpoint=STRING             OpenTelemetry endpoint for traces ($OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).
+      --otlp-metrics-endpoint=STRING            OpenTelemetry endpoint for metrics ($OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).
+      --otlp-logs-endpoint=STRING               OpenTelemetry endpoint for logs ($OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).
+      --otlp-insecure                           Disable LTS for OpenTelemetry exporters ($OTEL_EXPORTER_OTLP_INSECURE).
+      --otlp-traces-insecure                    Disable LTS for OpenTelemetry traces exporter ($OTEL_EXPORTER_OTLP_TRACES_INSECURE).
+      --otlp-metrics-insecure                   Disable LTS for OpenTelemetry metrics exporter ($OTEL_EXPORTER_OTLP_METRICS_INSECURE).
+      --otlp-logs-insecure                      Disable LTS for OpenTelemetry logs exporter ($OTEL_EXPORTER_OTLP_LOGS_INSECURE).
+      --otlp-protocol=STRING                    OpenTelemetry receiver protocol for all types ($OTEL_EXPORTER_OTLP_PROTOCOL).
+      --otlp-traces-protocol=STRING             OpenTelemetry receiver protocol for traces ($OTEL_EXPORTER_OTLP_TRACES_PROTOCOL).
+      --otlp-metrics-protocol=STRING            OpenTelemetry receiver protocol for metrics ($OTEL_EXPORTER_OTLP_METRICS_PROTOCOL).
+      --otlp-logs-protocol=STRING               OpenTelemetry receiver protocol for logs ($OTEL_EXPORTER_OTLP_LOGS_PROTOCOL).
+      --otlp-compression="gzip"                 Enable compression for OTLP exporters. Accept: none, gzip ($OTEL_EXPORTER_OTLP_COMPRESSION)
+      --otlp-trace-compression="gzip"           Enable compression for OTLP traces exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_TRACES_COMPRESSION)
+      --otlp-metrics-compression="gzip"         Enable compression for OTLP metrics exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_METRICS_COMPRESSION)
+      --otlp-logs-compression="gzip"            Enable compression for OTLP logs exporter. Accept: none, gzip ($OTEL_EXPORTER_OTLP_LOGS_COMPRESSION)
+      --metrics-exporter="none"                 Metrics export type. Accept: none, otlp, prometheus ($OTEL_METRICS_EXPORTER)
+      --logs-exporter="none"                    Logs export type. Accept: none, otlp ($OTEL_LOGS_EXPORTER)
+      --prometheus-port=PROMETHEUS-PORT         Prometheus port for the Prometheus HTTP server. Use /metrics endpoint of the connector server if empty
+                                                ($OTEL_EXPORTER_PROMETHEUS_PORT)
+      --disable-go-metrics                      Disable internal Go and process metrics
+      --server-read-timeout=DURATION            Maximum duration for reading the entire request, including the body. A zero or negative value means there
+                                                will be no timeout ($HASURA_SERVER_READ_TIMEOUT)
+      --server-read-header-timeout=DURATION     Amount of time allowed to read request headers. If zero, the value of ReadTimeout is used
+                                                ($HASURA_SERVER_READ_HEADER_TIMEOUT)
+      --server-write-timeout=DURATION           Maximum duration before timing out writes of the response. A zero or negative value means there will be no
+                                                timeout ($HASURA_SERVER_WRITE_TIMEOUT)
+      --server-idle-timeout=DURATION            Maximum amount of time to wait for the next request when keep-alives are enabled. If zero, the value of
+                                                ReadTimeout is used ($HASURA_SERVER_IDLE_TIMEOUT)
+      --server-max-header-kilobytes=1024        Maximum number of kilobytes the server will read parsing the request header's keys and values, including the
+                                                request line ($HASURA_SERVER_MAX_HEADER_KILOBYTES)
+      --server-max-body-megabytes=30            Maximum size of the request body in megabytes that the server accepts ($HASURA_SERVER_MAX_BODY_MEGABYTES)
+      --server-default-http-error-status=422    Default HTTP status code if the error does not specify the explicit status
+                                                ($HASURA_SERVER_DEFAULT_HTTP_ERROR_STATUS)
+      --server-tls-cert-file=STRING             Path of the TLS certificate file ($HASURA_SERVER_TLS_CERT_FILE)
+      --server-tls-key-file=STRING              Path of the TLS key file ($HASURA_SERVER_TLS_KEY_FILE)
+      --configuration=STRING                    Configuration directory ($HASURA_CONFIGURATION_DIRECTORY)
+      --port=8080                               Serve Port ($HASURA_CONNECTOR_PORT)
+      --service-token-secret=STRING             Service token secret ($HASURA_SERVICE_TOKEN_SECRET)
 ```
 
 Please refer to the [NDC Spec](https://hasura.github.io/ndc-spec/) for details on implementing the Connector interface, or see [examples](./example).
@@ -136,6 +140,14 @@ The prefix is empty by default. You can set the prefix for your connector by `Wi
 ### Logging
 
 NDC Go SDK uses the standard [log/slog](https://pkg.go.dev/log/slog) that provides highly customizable and structured logging. By default, the logger is printed in JSON format and configurable level with `--log-level` (HASURA_LOG_LEVEL) flag. You also can replace it with different logging libraries that can wrap the `slog.Handler` interface, and set the logger with the `WithLogger` or `WithLoggerFunc` option.
+
+## Best Practices 
+
+### Error Handling
+
+You should wraps exception errors with the `ConnectorError` struct and specify the explicit HTTP error status. `HASURA_SERVER_DEFAULT_HTTP_ERROR_STATUS` (default to `422`) will be returned if you don't wrap the error. The connector supports helper functions to create connector errors in the [schema](./schema/error.go) package.
+
+The Hasura engine v3 shows the explicit error content only if the connector returns HTTP 422 Unprocessable Content. Otherwise, the general internal error is responded. Therefore, you should actively control which error is safe to show it to end users.
 
 ## Customize the CLI
 

--- a/cmd/hasura-ndc-go/command/internal/templates/new/connector.go.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/templates/new/connector.go.tmpl
@@ -9,7 +9,7 @@ import (
 )
 
 var connectorCapabilities = schema.CapabilitiesResponse{
-	Version: "0.1.6",
+	Version: schema.NDCVersion,
 	Capabilities: schema.Capabilities{
 		Query: schema.QueryCapabilities{
 			Variables:    schema.LeafCapability{},

--- a/connector/http.go
+++ b/connector/http.go
@@ -332,7 +332,7 @@ func writeJson(w http.ResponseWriter, logger *slog.Logger, statusCode int, body 
 	})
 }
 
-func writeError(w http.ResponseWriter, logger *slog.Logger, err error) int {
+func writeError(w http.ResponseWriter, logger *slog.Logger, err error, defaultHttpStatus int) int {
 	w.Header().Add("Content-Type", "application/json")
 
 	var connectorErrorPtr *schema.ConnectorError
@@ -344,19 +344,19 @@ func writeError(w http.ResponseWriter, logger *slog.Logger, err error) int {
 
 	var errorResponse schema.ErrorResponse
 	if errors.As(err, &errorResponse) {
-		writeJson(w, logger, http.StatusBadRequest, errorResponse)
+		writeJson(w, logger, defaultHttpStatus, errorResponse)
 
 		return http.StatusInternalServerError
 	}
 
 	var errorResponsePtr *schema.ErrorResponse
 	if errors.As(err, &errorResponsePtr) {
-		writeJson(w, logger, http.StatusBadRequest, errorResponsePtr)
+		writeJson(w, logger, defaultHttpStatus, errorResponsePtr)
 
 		return http.StatusInternalServerError
 	}
 
-	writeJson(w, logger, http.StatusBadRequest, schema.ErrorResponse{
+	writeJson(w, logger, defaultHttpStatus, schema.ErrorResponse{
 		Message: err.Error(),
 	})
 

--- a/connector/server.go
+++ b/connector/server.go
@@ -366,6 +366,8 @@ func (s *Server[Configuration, State]) unmarshalBodyJSON(w http.ResponseWriter, 
 			failureStatusAttribute,
 			httpStatusAttribute(http.StatusUnprocessableEntity),
 		))
+
+		return err
 	}
 
 	return s.validateMaxBodySize(w, r, counter, requestReader.size)

--- a/connector/server.go
+++ b/connector/server.go
@@ -339,8 +339,6 @@ func (s *Server[Configuration, State]) Mutation(w http.ResponseWriter, r *http.R
 
 // the common unmarshal json body method.
 func (s *Server[Configuration, State]) unmarshalBodyJSON(w http.ResponseWriter, r *http.Request, counter metric.Int64Counter, body any) error {
-	defer r.Body.Close()
-
 	// Validate the max body size. In the worst scenario, if the Content-Length header doesn't exist,
 	// the server will validate again after reading the body.
 	if r.ContentLength > 0 {

--- a/connector/server.go
+++ b/connector/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"time"
 
@@ -35,14 +36,32 @@ type ServerOptions struct {
 
 // HTTPServerConfig the configuration of the HTTP server.
 type HTTPServerConfig struct {
-	ServerReadTimeout        time.Duration `help:"Maximum duration for reading the entire request, including the body. A zero or negative value means there will be no timeout" env:"HASURA_SERVER_READ_TIMEOUT"`
-	ServerReadHeaderTimeout  time.Duration `help:"Amount of time allowed to read request headers. If zero, the value of ReadTimeout is used" env:"HASURA_SERVER_READ_HEADER_TIMEOUT"`
-	ServerWriteTimeout       time.Duration `help:"Maximum duration before timing out writes of the response. A zero or negative value means there will be no timeout" env:"HASURA_SERVER_WRITE_TIMEOUT"`
-	ServerIdleTimeout        time.Duration `help:"Maximum amount of time to wait for the next request when keep-alives are enabled. If zero, the value of ReadTimeout is used" env:"HASURA_SERVER_IDLE_TIMEOUT"`
-	ServerMaxHeaderKilobytes int           `help:"Maximum number of kilobytes the server will read parsing the request header's keys and values, including the request line" default:"1024" env:"HASURA_SERVER_MAX_HEADER_KILOBYTES"`
-	ServerMaxBodyMegabytes   int           `help:"Maximum size of the request body in megabytes that the server accepts" default:"30" env:"HASURA_SERVER_MAX_BODY_MEGABYTES"`
-	ServerTLSCertFile        string        `help:"Path of the TLS certificate file" env:"HASURA_SERVER_TLS_CERT_FILE"`
-	ServerTLSKeyFile         string        `help:"Path of the TLS key file" env:"HASURA_SERVER_TLS_KEY_FILE"`
+	ServerReadTimeout            time.Duration `help:"Maximum duration for reading the entire request, including the body. A zero or negative value means there will be no timeout" env:"HASURA_SERVER_READ_TIMEOUT"`
+	ServerReadHeaderTimeout      time.Duration `help:"Amount of time allowed to read request headers. If zero, the value of ReadTimeout is used" env:"HASURA_SERVER_READ_HEADER_TIMEOUT"`
+	ServerWriteTimeout           time.Duration `help:"Maximum duration before timing out writes of the response. A zero or negative value means there will be no timeout" env:"HASURA_SERVER_WRITE_TIMEOUT"`
+	ServerIdleTimeout            time.Duration `help:"Maximum amount of time to wait for the next request when keep-alives are enabled. If zero, the value of ReadTimeout is used" env:"HASURA_SERVER_IDLE_TIMEOUT"`
+	ServerMaxHeaderKilobytes     int           `help:"Maximum number of kilobytes the server will read parsing the request header's keys and values, including the request line" default:"1024" env:"HASURA_SERVER_MAX_HEADER_KILOBYTES"`
+	ServerMaxBodyMegabytes       int           `help:"Maximum size of the request body in megabytes that the server accepts" default:"30" env:"HASURA_SERVER_MAX_BODY_MEGABYTES"`
+	ServerDefaultHTTPErrorStatus int           `help:"Default HTTP status code if the error does not specify the explicit status" enum:"400,422,500" default:"422" env:"HASURA_SERVER_DEFAULT_HTTP_ERROR_STATUS"`
+	ServerTLSCertFile            string        `help:"Path of the TLS certificate file" env:"HASURA_SERVER_TLS_CERT_FILE"`
+	ServerTLSKeyFile             string        `help:"Path of the TLS key file" env:"HASURA_SERVER_TLS_KEY_FILE"`
+}
+
+// Validate checks valid configurations and set default values.
+func (hsc *HTTPServerConfig) Validate() error {
+	if hsc.ServerMaxBodyMegabytes <= 0 {
+		hsc.ServerMaxBodyMegabytes = 30
+	}
+
+	allowedHttpErrorCodes := []int{http.StatusBadRequest, http.StatusUnprocessableEntity, http.StatusInternalServerError}
+
+	if hsc.ServerDefaultHTTPErrorStatus == 0 {
+		hsc.ServerDefaultHTTPErrorStatus = http.StatusUnprocessableEntity
+	} else if !slices.Contains(allowedHttpErrorCodes, hsc.ServerDefaultHTTPErrorStatus) {
+		return fmt.Errorf("invalid default server http error code, accepted one of %v, got: %d", allowedHttpErrorCodes, hsc.ServerDefaultHTTPErrorStatus)
+	}
+
+	return nil
 }
 
 // Server implements the [NDC API specification] for the connector
@@ -70,6 +89,11 @@ func NewServer[Configuration any, State any](connector Connector[Configuration, 
 	if options.ServiceName == "" {
 		options.OTLPConfig.ServiceName = defaultOptions.serviceName
 	}
+
+	if err := options.HTTPServerConfig.Validate(); err != nil {
+		return nil, err
+	}
+
 	defaultOptions.logger.Debug(
 		"initialize OpenTelemetry",
 		slog.Any("otlp", options.OTLPConfig),
@@ -94,10 +118,6 @@ func NewServer[Configuration any, State any](connector Connector[Configuration, 
 	state, err := connector.TryInitState(ctx, configuration, telemetry)
 	if err != nil {
 		return nil, err
-	}
-
-	if options.ServerMaxBodyMegabytes <= 0 {
-		options.ServerMaxBodyMegabytes = 30
 	}
 
 	return &Server[Configuration, State]{
@@ -140,7 +160,7 @@ func (s *Server[Configuration, State]) GetCapabilities(w http.ResponseWriter, r 
 	logger := GetLogger(r.Context())
 	capabilities := s.connector.GetCapabilities(s.configuration)
 	if capabilities == nil {
-		writeError(w, logger, schema.InternalServerError("capabilities is empty", nil))
+		s.writeError(w, logger, schema.InternalServerError("capabilities is empty", nil))
 		return
 	}
 	writeJsonFunc(w, logger, http.StatusOK, func() ([]byte, error) {
@@ -152,7 +172,7 @@ func (s *Server[Configuration, State]) GetCapabilities(w http.ResponseWriter, r 
 func (s *Server[Configuration, State]) Health(w http.ResponseWriter, r *http.Request) {
 	logger := GetLogger(r.Context())
 	if err := s.connector.HealthCheck(r.Context(), s.configuration, s.state); err != nil {
-		writeError(w, logger, err)
+		s.writeError(w, logger, err)
 		return
 	}
 
@@ -164,11 +184,11 @@ func (s *Server[Configuration, State]) GetSchema(w http.ResponseWriter, r *http.
 	logger := GetLogger(r.Context())
 	schemaResult, err := s.connector.GetSchema(r.Context(), s.configuration, s.state)
 	if err != nil {
-		writeError(w, logger, err)
+		s.writeError(w, logger, err)
 		return
 	}
 	if schemaResult == nil {
-		writeError(w, logger, schema.InternalServerError("schema is empty", nil))
+		s.writeError(w, logger, schema.InternalServerError("schema is empty", nil))
 		return
 	}
 
@@ -194,7 +214,7 @@ func (s *Server[Configuration, State]) Query(w http.ResponseWriter, r *http.Requ
 
 	response, err := s.connector.Query(execQueryCtx, s.configuration, s.state, &body)
 	if err != nil {
-		status := writeError(w, logger, err)
+		status := s.writeError(w, logger, err)
 		s.telemetry.queryCounter.Add(r.Context(), 1, metric.WithAttributes(
 			collectionAttr,
 			failureStatusAttribute,
@@ -230,7 +250,7 @@ func (s *Server[Configuration, State]) QueryExplain(w http.ResponseWriter, r *ht
 
 	response, err := s.connector.QueryExplain(execCtx, s.configuration, s.state, &body)
 	if err != nil {
-		status := writeError(w, logger, err)
+		status := s.writeError(w, logger, err)
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
 
@@ -273,7 +293,7 @@ func (s *Server[Configuration, State]) MutationExplain(w http.ResponseWriter, r 
 
 	response, err := s.connector.MutationExplain(execCtx, s.configuration, s.state, &body)
 	if err != nil {
-		status := writeError(w, logger, err)
+		status := s.writeError(w, logger, err)
 
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
@@ -316,7 +336,7 @@ func (s *Server[Configuration, State]) Mutation(w http.ResponseWriter, r *http.R
 	defer execSpan.End()
 	response, err := s.connector.Mutation(execCtx, s.configuration, s.state, &body)
 	if err != nil {
-		status := writeError(w, logger, err)
+		status := s.writeError(w, logger, err)
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
 
@@ -389,6 +409,10 @@ func (s *Server[Configuration, State]) validateMaxBodySize(w http.ResponseWriter
 	))
 
 	return err
+}
+
+func (s *Server[Configuration, State]) writeError(w http.ResponseWriter, logger *slog.Logger, err error) int {
+	return writeError(w, logger, err, s.options.ServerDefaultHTTPErrorStatus)
 }
 
 func (s *Server[Configuration, State]) buildHandler() *http.ServeMux {

--- a/credentials/credentials_provider.go
+++ b/credentials/credentials_provider.go
@@ -82,7 +82,7 @@ func (cc *CredentialClient) reload() error {
 
 // AcquireCredentials calls the credentials provider webhook to get the credentials for the given key.
 func (cc *CredentialClient) AcquireCredentials(ctx context.Context, key string, forceRefresh bool) (string, error) {
-	ctx, span := tracer.Start(ctx, "AcquireCredentials", trace.WithSpanKind(trace.SpanKindClient))
+	ctx, span := tracer.Start(ctx, "AcquireCredentials", trace.WithSpanKind(trace.SpanKindClient), trace.WithAttributes(attribute.String("internal.visibility", "user")))
 	defer span.End()
 
 	if forceRefresh || cc.providerUri == nil {

--- a/example/codegen/connector.go
+++ b/example/codegen/connector.go
@@ -9,7 +9,7 @@ import (
 )
 
 var connectorCapabilities = schema.CapabilitiesResponse{
-	Version: "0.1.6",
+	Version: schema.NDCVersion,
 	Capabilities: schema.Capabilities{
 		Query: schema.QueryCapabilities{
 			Variables:    schema.LeafCapability{},

--- a/schema/type.go
+++ b/schema/type.go
@@ -7,6 +7,11 @@ import (
 	"slices"
 )
 
+const (
+	// NDCVersion holds the current supported version of the NDC Go SDK.
+	NDCVersion = "0.1.6"
+)
+
 /*
  * Types track the valid representations of values as JSON
  */


### PR DESCRIPTION
This pull request introduces several updates, primarily focused on adding request body size validation to the server, improving error handling, and enhancing test coverage. Additionally, it includes minor versioning and tracing updates. Below is a summary of the most important changes grouped by theme:

* Added a `ServerMaxBodyMegabytes` (`HASURA_SERVER_MAX_BODY_MEGABYTES`) configuration to limit the maximum request body size, with a default value of 30 MB. This is now part of the `HTTPServerConfig` struct. (`connector/server.go` - [[1]](diffhunk://#diff-83302262c5bae5edff30c79b5c66523a44fbf1435e957341aab5a68306140546R43) [[2]](diffhunk://#diff-83302262c5bae5edff30c79b5c66523a44fbf1435e957341aab5a68306140546R99-R102)
* Added a `ServerDefaultHTTPErrorStatus` (`HASURA_SERVER_DEFAULT_HTTP_ERROR_STATUS `) configuration to return the default HTTP error status if developers don't explicitly set it, with a default value of `422`. This is now part of the `HTTPServerConfig` struct.
* Replaced hardcoded version strings with a centralized `NDCVersion` constant in `schema/type.go`. Updated references in `connector.go` and `example/codegen/connector.go`. (`schema/type.go` - [[1]](diffhunk://#diff-b871255a9c2c4e38e9ab6f8a71da8a7e3fb54e61a87d7e7c1919d232a8327972R10-R14) `cmd/hasura-ndc-go/command/internal/templates/new/connector.go.tmpl` - [[2]](diffhunk://#diff-3229f2f55f3d561649a3bd83e14124448a8cd3b531ecd30201c6fd97e2ba8dc4L12-R12) `example/codegen/connector.go` - [[3]](diffhunk://#diff-125595dde115bd1772302e40b35502ba89ab4b65f8fbee10c8e98ff018c7cd4fL12-R12)
* Enhanced tracing in `AcquireCredentials` to include a new attribute for internal visibility. (`credentials/credentials_provider.go` - [credentials/credentials_provider.goL85-R85](diffhunk://#diff-fa69c25a2aabc712d881e78e84c9934c31313f48abc0b680619b5a4f6013eb29L85-R85))