### PR TITLE
ci: upgrade ubuntu latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
 
   build-cli-binaries:
     name: build the CLI binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [tests]
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use the latest Ubuntu version for building CLI binaries.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL13-R13): Changed the `runs-on` parameter for the `build-cli-binaries` job from `ubuntu-20.04` to `ubuntu-latest` to ensure the workflow uses the most up-to-date environment.