### PR TITLE
sdk: improve generic constructor functions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           only-new-issues: true

--- a/schema/extend.go
+++ b/schema/extend.go
@@ -1791,7 +1791,9 @@ func (f ComparisonValueColumn) WithFieldPath(fieldPath []string) *ComparisonValu
 }
 
 // WithArguments return a new instance with arguments set.
-func (f ComparisonValueColumn) WithArguments(arguments map[string]ArgumentEncoder) *ComparisonValueColumn {
+func (f ComparisonValueColumn) WithArguments(
+	arguments map[string]ArgumentEncoder,
+) *ComparisonValueColumn {
 	if arguments == nil {
 		f.Arguments = nil
 
@@ -2400,14 +2402,18 @@ func (ei ExistsInCollectionNestedCollection) Type() ExistsInCollectionType {
 }
 
 // WithFieldPath returns a new instance with field_path set.
-func (f ExistsInCollectionNestedCollection) WithFieldPath(fieldPath []string) *ExistsInCollectionNestedCollection {
+func (f ExistsInCollectionNestedCollection) WithFieldPath(
+	fieldPath []string,
+) *ExistsInCollectionNestedCollection {
 	f.FieldPath = fieldPath
 
 	return &f
 }
 
 // WithArguments return a new instance with arguments set.
-func (f ExistsInCollectionNestedCollection) WithArguments(arguments map[string]ArgumentEncoder) *ExistsInCollectionNestedCollection {
+func (f ExistsInCollectionNestedCollection) WithArguments(
+	arguments map[string]ArgumentEncoder,
+) *ExistsInCollectionNestedCollection {
 	if arguments == nil {
 		f.Arguments = nil
 
@@ -2479,7 +2485,9 @@ type ExistsInCollectionNestedScalarCollection struct {
 }
 
 // NewExistsInCollectionNestedScalarCollection creates an ExistsInCollectionNestedScalarCollection instance.
-func NewExistsInCollectionNestedScalarCollection(columnName string) *ExistsInCollectionNestedScalarCollection {
+func NewExistsInCollectionNestedScalarCollection(
+	columnName string,
+) *ExistsInCollectionNestedScalarCollection {
 	return &ExistsInCollectionNestedScalarCollection{
 		ColumnName: columnName,
 	}
@@ -2491,14 +2499,18 @@ func (ei ExistsInCollectionNestedScalarCollection) Type() ExistsInCollectionType
 }
 
 // WithFieldPath returns a new instance with field_path set.
-func (f ExistsInCollectionNestedScalarCollection) WithFieldPath(fieldPath []string) *ExistsInCollectionNestedScalarCollection {
+func (f ExistsInCollectionNestedScalarCollection) WithFieldPath(
+	fieldPath []string,
+) *ExistsInCollectionNestedScalarCollection {
 	f.FieldPath = fieldPath
 
 	return &f
 }
 
 // WithArguments return a new instance with arguments set.
-func (f ExistsInCollectionNestedScalarCollection) WithArguments(arguments map[string]ArgumentEncoder) *ExistsInCollectionNestedScalarCollection {
+func (f ExistsInCollectionNestedScalarCollection) WithArguments(
+	arguments map[string]ArgumentEncoder,
+) *ExistsInCollectionNestedScalarCollection {
 	if arguments == nil {
 		f.Arguments = nil
 
@@ -3776,7 +3788,9 @@ func (f AggregateSingleColumn) WithFieldPath(fieldPath []string) *AggregateSingl
 }
 
 // WithArguments return a new instance with arguments set.
-func (f AggregateSingleColumn) WithArguments(arguments map[string]ArgumentEncoder) *AggregateSingleColumn {
+func (f AggregateSingleColumn) WithArguments(
+	arguments map[string]ArgumentEncoder,
+) *AggregateSingleColumn {
 	if arguments == nil {
 		f.Arguments = nil
 

--- a/schema/extend.go
+++ b/schema/extend.go
@@ -1771,25 +1771,71 @@ type ComparisonValueColumn struct {
 }
 
 // NewComparisonValueColumn creates a new ComparisonValueColumn instance.
-func NewComparisonValueColumn(
-	name string,
-	path []PathElement,
-	arguments map[string]Argument,
-	fieldPath []string,
-	scope *uint,
-) *ComparisonValueColumn {
+func NewComparisonValueColumn(name string, path []PathElement) *ComparisonValueColumn {
 	return &ComparisonValueColumn{
-		Name:      name,
-		Path:      path,
-		Arguments: arguments,
-		FieldPath: fieldPath,
-		Scope:     scope,
+		Name: name,
+		Path: path,
 	}
 }
 
 // Type return the type name of the instance.
 func (cv ComparisonValueColumn) Type() ComparisonValueType {
 	return ComparisonValueTypeColumn
+}
+
+// WithFieldPath returns a new instance with field_path set.
+func (f ComparisonValueColumn) WithFieldPath(fieldPath []string) *ComparisonValueColumn {
+	f.FieldPath = fieldPath
+
+	return &f
+}
+
+// WithArguments return a new instance with arguments set.
+func (f ComparisonValueColumn) WithArguments(arguments map[string]ArgumentEncoder) *ComparisonValueColumn {
+	if arguments == nil {
+		f.Arguments = nil
+
+		return &f
+	}
+
+	args := make(map[string]Argument)
+
+	for key, arg := range arguments {
+		if arg == nil {
+			continue
+		}
+
+		args[key] = arg.Encode()
+	}
+
+	f.Arguments = args
+
+	return &f
+}
+
+// WithArgument return a new instance with an arguments set.
+func (f ComparisonValueColumn) WithArgument(
+	key string,
+	argument ArgumentEncoder,
+) *ComparisonValueColumn {
+	if argument == nil {
+		delete(f.Arguments, key)
+	} else {
+		if f.Arguments == nil {
+			f.Arguments = make(map[string]Argument)
+		}
+
+		f.Arguments[key] = argument.Encode()
+	}
+
+	return &f
+}
+
+// WithScope return a new instance with a scope set.
+func (f ComparisonValueColumn) WithScope(scope *uint) *ComparisonValueColumn {
+	f.Scope = scope
+
+	return &f
 }
 
 // Encode converts to the raw comparison value.
@@ -2342,21 +2388,63 @@ type ExistsInCollectionNestedCollection struct {
 }
 
 // NewExistsInCollectionNestedCollection creates an ExistsInCollectionNestedCollection instance.
-func NewExistsInCollectionNestedCollection(
-	columnName string,
-	arguments map[string]Argument,
-	fieldPath []string,
-) *ExistsInCollectionNestedCollection {
+func NewExistsInCollectionNestedCollection(columnName string) *ExistsInCollectionNestedCollection {
 	return &ExistsInCollectionNestedCollection{
 		ColumnName: columnName,
-		Arguments:  arguments,
-		FieldPath:  fieldPath,
 	}
 }
 
 // Type return the type name of the instance.
 func (ei ExistsInCollectionNestedCollection) Type() ExistsInCollectionType {
 	return ExistsInCollectionTypeNestedCollection
+}
+
+// WithFieldPath returns a new instance with field_path set.
+func (f ExistsInCollectionNestedCollection) WithFieldPath(fieldPath []string) *ExistsInCollectionNestedCollection {
+	f.FieldPath = fieldPath
+
+	return &f
+}
+
+// WithArguments return a new instance with arguments set.
+func (f ExistsInCollectionNestedCollection) WithArguments(arguments map[string]ArgumentEncoder) *ExistsInCollectionNestedCollection {
+	if arguments == nil {
+		f.Arguments = nil
+
+		return &f
+	}
+
+	args := make(map[string]Argument)
+
+	for key, arg := range arguments {
+		if arg == nil {
+			continue
+		}
+
+		args[key] = arg.Encode()
+	}
+
+	f.Arguments = args
+
+	return &f
+}
+
+// WithArgument return a new instance with an arguments set.
+func (f ExistsInCollectionNestedCollection) WithArgument(
+	key string,
+	argument ArgumentEncoder,
+) *ExistsInCollectionNestedCollection {
+	if argument == nil {
+		delete(f.Arguments, key)
+	} else {
+		if f.Arguments == nil {
+			f.Arguments = make(map[string]Argument)
+		}
+
+		f.Arguments[key] = argument.Encode()
+	}
+
+	return &f
 }
 
 // Encode converts the instance to its raw type.
@@ -2391,21 +2479,63 @@ type ExistsInCollectionNestedScalarCollection struct {
 }
 
 // NewExistsInCollectionNestedScalarCollection creates an ExistsInCollectionNestedScalarCollection instance.
-func NewExistsInCollectionNestedScalarCollection(
-	columnName string,
-	arguments map[string]Argument,
-	fieldPath []string,
-) *ExistsInCollectionNestedScalarCollection {
+func NewExistsInCollectionNestedScalarCollection(columnName string) *ExistsInCollectionNestedScalarCollection {
 	return &ExistsInCollectionNestedScalarCollection{
 		ColumnName: columnName,
-		Arguments:  arguments,
-		FieldPath:  fieldPath,
 	}
 }
 
 // Type return the type name of the instance.
 func (ei ExistsInCollectionNestedScalarCollection) Type() ExistsInCollectionType {
 	return ExistsInCollectionTypeNestedScalarCollection
+}
+
+// WithFieldPath returns a new instance with field_path set.
+func (f ExistsInCollectionNestedScalarCollection) WithFieldPath(fieldPath []string) *ExistsInCollectionNestedScalarCollection {
+	f.FieldPath = fieldPath
+
+	return &f
+}
+
+// WithArguments return a new instance with arguments set.
+func (f ExistsInCollectionNestedScalarCollection) WithArguments(arguments map[string]ArgumentEncoder) *ExistsInCollectionNestedScalarCollection {
+	if arguments == nil {
+		f.Arguments = nil
+
+		return &f
+	}
+
+	args := make(map[string]Argument)
+
+	for key, arg := range arguments {
+		if arg == nil {
+			continue
+		}
+
+		args[key] = arg.Encode()
+	}
+
+	f.Arguments = args
+
+	return &f
+}
+
+// WithArgument return a new instance with an arguments set.
+func (f ExistsInCollectionNestedScalarCollection) WithArgument(
+	key string,
+	argument ArgumentEncoder,
+) *ExistsInCollectionNestedScalarCollection {
+	if argument == nil {
+		delete(f.Arguments, key)
+	} else {
+		if f.Arguments == nil {
+			f.Arguments = make(map[string]Argument)
+		}
+
+		f.Arguments[key] = argument.Encode()
+	}
+
+	return &f
 }
 
 // Encode converts the instance to its raw type.
@@ -3626,23 +3756,64 @@ type AggregateSingleColumn struct {
 }
 
 // NewAggregateSingleColumn creates a new AggregateSingleColumn instance.
-func NewAggregateSingleColumn(
-	column string,
-	function string,
-	fieldPath []string,
-	arguments map[string]Argument,
-) *AggregateSingleColumn {
+func NewAggregateSingleColumn(column string, function string) *AggregateSingleColumn {
 	return &AggregateSingleColumn{
-		Column:    column,
-		Function:  function,
-		FieldPath: fieldPath,
-		Arguments: arguments,
+		Column:   column,
+		Function: function,
 	}
 }
 
 // Type return the type name of the instance.
 func (ag AggregateSingleColumn) Type() AggregateType {
 	return AggregateTypeSingleColumn
+}
+
+// WithFieldPath returns a new instance with field_path set.
+func (f AggregateSingleColumn) WithFieldPath(fieldPath []string) *AggregateSingleColumn {
+	f.FieldPath = fieldPath
+
+	return &f
+}
+
+// WithArguments return a new instance with arguments set.
+func (f AggregateSingleColumn) WithArguments(arguments map[string]ArgumentEncoder) *AggregateSingleColumn {
+	if arguments == nil {
+		f.Arguments = nil
+
+		return &f
+	}
+
+	args := make(map[string]Argument)
+
+	for key, arg := range arguments {
+		if arg == nil {
+			continue
+		}
+
+		args[key] = arg.Encode()
+	}
+
+	f.Arguments = args
+
+	return &f
+}
+
+// WithArgument return a new instance with an arguments set.
+func (f AggregateSingleColumn) WithArgument(
+	key string,
+	argument ArgumentEncoder,
+) *AggregateSingleColumn {
+	if argument == nil {
+		delete(f.Arguments, key)
+	} else {
+		if f.Arguments == nil {
+			f.Arguments = make(map[string]Argument)
+		}
+
+		f.Arguments[key] = argument.Encode()
+	}
+
+	return &f
 }
 
 // Encode converts the instance to raw Aggregate.
@@ -3678,23 +3849,66 @@ type AggregateColumnCount struct {
 }
 
 // NewAggregateColumnCount creates a new AggregateColumnCount instance.
-func NewAggregateColumnCount(
-	column string,
-	distinct bool,
-	fieldPath []string,
-	arguments map[string]Argument,
-) *AggregateColumnCount {
+func NewAggregateColumnCount(column string, distinct bool) *AggregateColumnCount {
 	return &AggregateColumnCount{
-		Column:    column,
-		Distinct:  distinct,
-		FieldPath: fieldPath,
-		Arguments: arguments,
+		Column:   column,
+		Distinct: distinct,
 	}
 }
 
 // Type return the type name of the instance.
 func (ag AggregateColumnCount) Type() AggregateType {
 	return AggregateTypeColumnCount
+}
+
+// WithFieldPath returns a new instance with field_path set.
+func (f AggregateColumnCount) WithFieldPath(fieldPath []string) *AggregateColumnCount {
+	f.FieldPath = fieldPath
+
+	return &f
+}
+
+// WithArguments return a new instance with arguments set.
+func (f AggregateColumnCount) WithArguments(
+	arguments map[string]ArgumentEncoder,
+) *AggregateColumnCount {
+	if arguments == nil {
+		f.Arguments = nil
+
+		return &f
+	}
+
+	args := make(map[string]Argument)
+
+	for key, arg := range arguments {
+		if arg == nil {
+			continue
+		}
+
+		args[key] = arg.Encode()
+	}
+
+	f.Arguments = args
+
+	return &f
+}
+
+// WithArgument return a new instance with an arguments set.
+func (f AggregateColumnCount) WithArgument(
+	key string,
+	argument ArgumentEncoder,
+) *AggregateColumnCount {
+	if argument == nil {
+		delete(f.Arguments, key)
+	} else {
+		if f.Arguments == nil {
+			f.Arguments = make(map[string]Argument)
+		}
+
+		f.Arguments[key] = argument.Encode()
+	}
+
+	return &f
 }
 
 // Encode converts the instance to raw Aggregate.

--- a/schema/query.go
+++ b/schema/query.go
@@ -323,7 +323,7 @@ type ArrayComparisonContains struct {
 }
 
 // NewArrayComparisonContains creates an ArrayComparisonContains instance.
-func NewArrayComparisonContains(value ComparisonValueEncoder) *ArrayComparisonContains {
+func NewArrayComparisonContains[T ComparisonValueEncoder](value T) *ArrayComparisonContains {
 	return &ArrayComparisonContains{
 		Value: value.Encode(),
 	}
@@ -346,9 +346,7 @@ func (j ArrayComparisonContains) Encode() ArrayComparison {
 
 // ArrayComparisonIsEmpty checks if the array is empty.
 // Only used if the 'query.nested_fields.filter_by.nested_arrays.is_empty' capability is supported.
-type ArrayComparisonIsEmpty struct {
-	Value ComparisonValue `json:"value" mapstructure:"value" yaml:"value"`
-}
+type ArrayComparisonIsEmpty struct{}
 
 // NewArrayComparisonIsEmpty creates an ArrayComparisonIsEmpty instance.
 func NewArrayComparisonIsEmpty() *ArrayComparisonIsEmpty {

--- a/schema/scalar.go
+++ b/schema/scalar.go
@@ -2423,7 +2423,9 @@ type AggregateFunctionDefinitionCustom struct {
 }
 
 // NewAggregateFunctionDefinitionCustom creates an AggregateFunctionDefinitionCustom instance.
-func NewAggregateFunctionDefinitionCustom[T TypeEncoder](resultType T) *AggregateFunctionDefinitionCustom {
+func NewAggregateFunctionDefinitionCustom[T TypeEncoder](
+	resultType T,
+) *AggregateFunctionDefinitionCustom {
 	return &AggregateFunctionDefinitionCustom{
 		ResultType: resultType.Encode(),
 	}

--- a/schema/scalar.go
+++ b/schema/scalar.go
@@ -2423,9 +2423,9 @@ type AggregateFunctionDefinitionCustom struct {
 }
 
 // NewAggregateFunctionDefinitionCustom creates an AggregateFunctionDefinitionCustom instance.
-func NewAggregateFunctionDefinitionCustom(resultType Type) *AggregateFunctionDefinitionCustom {
+func NewAggregateFunctionDefinitionCustom[T TypeEncoder](resultType T) *AggregateFunctionDefinitionCustom {
 	return &AggregateFunctionDefinitionCustom{
-		ResultType: resultType,
+		ResultType: resultType.Encode(),
 	}
 }
 
@@ -3135,7 +3135,7 @@ type ComparisonOperatorCustom struct {
 }
 
 // NewComparisonOperatorCustom create a new ComparisonOperatorCustom instance.
-func NewComparisonOperatorCustom(argumentType TypeEncoder) *ComparisonOperatorCustom {
+func NewComparisonOperatorCustom[T TypeEncoder](argumentType T) *ComparisonOperatorCustom {
 	return &ComparisonOperatorCustom{
 		ArgumentType: argumentType.Encode(),
 	}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -47,15 +47,11 @@ func TestQueryRequest(t *testing.T) {
 						"min_id": NewAggregateSingleColumn(
 							"id",
 							"min",
-							[]string{"foo"},
-							nil,
-						).Encode(),
+						).WithFieldPath([]string{"foo"}).Encode(),
 						"bar_count": NewAggregateColumnCount(
 							"id",
 							true,
-							[]string{"bar"},
-							nil,
-						).Encode(),
+						).WithFieldPath([]string{"bar"}).Encode(),
 					},
 				},
 				CollectionRelationships: QueryRequestCollectionRelationships{},
@@ -492,7 +488,7 @@ func TestQueryRequest(t *testing.T) {
 					Fields: QueryFields{
 						"articles_aggregate": NewRelationshipField(Query{
 							Aggregates: QueryAggregates{
-								"max_id": NewAggregateSingleColumn("id", "max", nil, nil).Encode(),
+								"max_id": NewAggregateSingleColumn("id", "max").Encode(),
 							},
 						}, "author_articles", map[string]RelationshipArgument{}).Encode(),
 					},
@@ -501,7 +497,7 @@ func TestQueryRequest(t *testing.T) {
 							{
 								OrderDirection: OrderDirectionAsc,
 								Target: NewOrderByAggregate(
-									NewAggregateSingleColumn("id", "max", nil, nil),
+									NewAggregateSingleColumn("id", "max"),
 									[]PathElement{
 										{
 											Arguments:    PathElementArguments{},
@@ -600,12 +596,9 @@ func TestQueryRequest(t *testing.T) {
 							"like",
 							NewComparisonValueScalar("s"),
 						),
-						NewExistsInCollectionNestedCollection("staff", map[string]Argument{
-							"limit": map[string]any{
-								"type":  "literal",
-								"value": nil,
-							},
-						}, nil),
+						NewExistsInCollectionNestedCollection("staff").WithArguments(map[string]ArgumentEncoder{
+							"limit": NewArgumentLiteral(nil),
+						}),
 					).Encode(),
 				},
 				CollectionRelationships: QueryRequestCollectionRelationships{},


### PR DESCRIPTION
This pull request refactors several constructors and introduces new methods to improve flexibility and usability in the `schema` package. The changes primarily focus on simplifying constructor signatures and adding methods for setting optional fields (`FieldPath`, `Arguments`, `Scope`, etc.) in a more modular way. Additionally, some test cases have been updated to align with these changes.

### Refactoring constructors and modular methods:

* **ComparisonValueColumn**:
  - Simplified the `NewComparisonValueColumn` constructor by removing optional parameters (`arguments`, `fieldPath`, and `scope`) and added modular methods like `WithFieldPath`, `WithArguments`, `WithArgument`, and `WithScope` to set these fields. (`[[1]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25L1774-L1786)`, `[[2]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25R1786-R1840)`)

* **ExistsInCollection types**:
  - Refactored constructors for `ExistsInCollectionNestedCollection` and `ExistsInCollectionNestedScalarCollection` to remove optional parameters. Added methods such as `WithFieldPath`, `WithArguments`, and `WithArgument` for setting optional fields. (`[[1]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25L2345-L2353)`, `[[2]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25R2402-R2449)`, `[[3]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25L2394-L2402)`, `[[4]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25R2493-R2540)`)

* **Aggregate types**:
  - Updated constructors for `AggregateSingleColumn` and `AggregateColumnCount` to remove optional parameters. Introduced methods like `WithFieldPath`, `WithArguments`, and `WithArgument` for setting optional fields. (`[[1]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25L3629-L3639)`, `[[2]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25R3771-R3818)`, `[[3]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25L3681-L3691)`, `[[4]](diffhunk://#diff-3da8cc43b4b3423f4d4efcab9ea4d0b65f2230292e86f0688f1d67ab96e0fc25R3864-R3913)`)

### Generic type improvements:

* **Generic constructors**:
  - Updated constructors like `NewArrayComparisonContains` and `NewAggregateFunctionDefinitionCustom` to use generics (`T`) for improved type safety and flexibility. (`[[1]](diffhunk://#diff-ba37191e8e7afa49b1784e4ffa77940130a9cdc805a665752c663d5b92dff16eL326-R326)`, `[[2]](diffhunk://#diff-1d44cc18f18d6c5b9d48fe6188b0b5a9c240202ca172a9248bee4df0908008bbL2426-R2428)`, `[[3]](diffhunk://#diff-1d44cc18f18d6c5b9d48fe6188b0b5a9c240202ca172a9248bee4df0908008bbL3138-R3138)`)