### PR TITLE
feat: support compression

### DIFF
--- a/cmd/hasura-ndc-go/command/internal/testdata/basic/source/go.mod
+++ b/cmd/hasura-ndc-go/command/internal/testdata/basic/source/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/cmd/hasura-ndc-go/command/internal/testdata/empty/source/go.mod
+++ b/cmd/hasura-ndc-go/command/internal/testdata/empty/source/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/cmd/hasura-ndc-go/command/internal/testdata/single_op/source/go.mod
+++ b/cmd/hasura-ndc-go/command/internal/testdata/single_op/source/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/cmd/hasura-ndc-go/command/internal/testdata/snake_case/source/go.mod
+++ b/cmd/hasura-ndc-go/command/internal/testdata/snake_case/source/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/connector/response.go
+++ b/connector/response.go
@@ -1,0 +1,71 @@
+package connector
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+
+	"github.com/hasura/ndc-sdk-go/utils/compression"
+)
+
+const (
+	acceptEncodingHeader  = "Accept-Encoding"
+	contentEncodingHeader = "Content-Encoding"
+)
+
+// define a custom response write to capture response information for logging.
+type customResponseWriter struct {
+	http.ResponseWriter
+
+	contentEncoding string
+	statusCode      int
+	bodyLength      int
+	body            []byte
+}
+
+var _ http.ResponseWriter = (*customResponseWriter)(nil)
+
+func newCustomResponseWriter(r *http.Request, w http.ResponseWriter) *customResponseWriter {
+	var contentEncoding string
+	acceptEncoding := r.Header.Get(acceptEncodingHeader)
+
+	if acceptEncoding != "" {
+		for enc := range strings.SplitSeq(acceptEncoding, ",") {
+			enc = strings.ToLower(strings.TrimSpace(enc))
+
+			if compression.DefaultCompressor.IsEncodingSupported(enc) {
+				contentEncoding = enc
+
+				break
+			}
+		}
+	}
+
+	return &customResponseWriter{
+		ResponseWriter:  w,
+		contentEncoding: contentEncoding,
+	}
+}
+
+func (cw *customResponseWriter) WriteHeader(statusCode int) {
+	cw.statusCode = statusCode
+
+	if cw.contentEncoding != "" {
+		cw.ResponseWriter.Header().Set(contentEncodingHeader, cw.contentEncoding)
+	}
+
+	cw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (cw *customResponseWriter) Write(body []byte) (int, error) {
+	cw.body = body
+	cw.bodyLength = len(body)
+
+	written, err := compression.DefaultCompressor.Compress(
+		cw.ResponseWriter,
+		cw.contentEncoding,
+		bytes.NewReader(body),
+	)
+
+	return int(written), err
+}

--- a/connector/response.go
+++ b/connector/response.go
@@ -27,6 +27,7 @@ var _ http.ResponseWriter = (*customResponseWriter)(nil)
 
 func newCustomResponseWriter(r *http.Request, w http.ResponseWriter) *customResponseWriter {
 	var contentEncoding string
+
 	acceptEncoding := r.Header.Get(acceptEncodingHeader)
 
 	if acceptEncoding != "" {

--- a/example/codegen/go.mod
+++ b/example/codegen/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
+	github.com/klauspost/compress v1.18.0
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/common v0.65.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.12.0

--- a/utils/compression/compression.go
+++ b/utils/compression/compression.go
@@ -1,0 +1,84 @@
+package compression
+
+import (
+	"io"
+	"strings"
+
+	"github.com/hasura/ndc-sdk-go/utils"
+)
+
+// DefaultCompressor the default compressors.
+var DefaultCompressor = NewCompressors()
+
+// Compressor abstracts the interface for a compression handler.
+type Compressor interface {
+	Compress(w io.Writer, src io.Reader) (int64, error)
+	Decompress(reader io.ReadCloser) (io.ReadCloser, error)
+}
+
+// Compressors is a general helper for web compression.
+type Compressors struct {
+	acceptEncoding string
+	compressors    map[string]Compressor
+}
+
+// NewCompressors create a Compressors instance.
+func NewCompressors() *Compressors {
+	compressors := map[string]Compressor{
+		EncodingGzip:    GzipCompressor{},
+		EncodingDeflate: DeflateCompressor{},
+		EncodingZstd:    ZstdCompressor{},
+	}
+
+	return &Compressors{
+		acceptEncoding: strings.Join(utils.GetSortedKeys(compressors), ", "),
+		compressors:    compressors,
+	}
+}
+
+// AcceptEncoding returns the Accept-Encoding header with supported compression encodings.
+func (c Compressors) AcceptEncoding() string {
+	return c.acceptEncoding
+}
+
+// IsEncodingSupported checks if the input encoding is supported.
+func (c Compressors) IsEncodingSupported(encoding string) bool {
+	_, ok := c.compressors[encoding]
+
+	return ok
+}
+
+// Compress writes compressed data.
+func (c Compressors) Compress(w io.Writer, encoding string, data io.Reader) (int64, error) {
+	compressor, ok := c.compressors[strings.ToLower(strings.TrimSpace(encoding))]
+	if !ok {
+		return io.Copy(w, data)
+	}
+
+	return compressor.Compress(w, data)
+}
+
+// Decompress reads and decompresses the reader with equivalent the content encoding.
+func (c Compressors) Decompress(reader io.ReadCloser, encoding string) (io.ReadCloser, error) {
+	compressor, ok := c.compressors[strings.ToLower(strings.TrimSpace(encoding))]
+	if !ok {
+		return reader, nil
+	}
+
+	return compressor.Decompress(reader)
+}
+
+type readCloserWrapper struct {
+	CompressionReader io.ReadCloser
+	OriginalReader    io.ReadCloser
+}
+
+func (rcw readCloserWrapper) Close() error {
+	_ = rcw.OriginalReader.Close()
+
+	return rcw.CompressionReader.Close()
+}
+
+func (rcw readCloserWrapper) Read(p []byte) (int, error) {
+	return rcw.CompressionReader.Read(p)
+}

--- a/utils/compression/deflate.go
+++ b/utils/compression/deflate.go
@@ -1,0 +1,45 @@
+package compression
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/flate"
+)
+
+const (
+	EncodingDeflate = "deflate"
+)
+
+// DeflateCompressor implements the compression handler for deflate encoding.
+type DeflateCompressor struct{}
+
+// Compress the reader content with deflate encoding.
+func (dc DeflateCompressor) Compress(w io.Writer, src io.Reader) (int64, error) {
+	fw, err := flate.NewWriter(w, flate.DefaultCompression)
+	if err != nil {
+		return 0, err
+	}
+
+	size, copyErr := io.Copy(fw, src)
+	closeErr := fw.Close()
+
+	if copyErr != nil {
+		return 0, copyErr
+	}
+
+	if closeErr != nil {
+		return 0, closeErr
+	}
+
+	return size, nil
+}
+
+// Decompress the reader content with deflate encoding.
+func (dc DeflateCompressor) Decompress(reader io.ReadCloser) (io.ReadCloser, error) {
+	compressionReader := flate.NewReader(reader)
+
+	return readCloserWrapper{
+		CompressionReader: compressionReader,
+		OriginalReader:    reader,
+	}, nil
+}

--- a/utils/compression/deflate.go
+++ b/utils/compression/deflate.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	EncodingDeflate = "deflate"
+	// EncodingDeflate represents the deflate compression format.
+	EncodingDeflate CompressionFormat = "deflate"
 )
 
 // DeflateCompressor implements the compression handler for deflate encoding.

--- a/utils/compression/gzip.go
+++ b/utils/compression/gzip.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	EncodingGzip = "gzip"
+	// EncodingGzip represents the gzip compression format.
+	EncodingGzip CompressionFormat = "gzip"
 )
 
 // GzipCompressor implements the compression handler for gzip encoding.

--- a/utils/compression/gzip.go
+++ b/utils/compression/gzip.go
@@ -1,0 +1,37 @@
+package compression
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/gzip"
+)
+
+const (
+	EncodingGzip = "gzip"
+)
+
+// GzipCompressor implements the compression handler for gzip encoding.
+type GzipCompressor struct{}
+
+// Compress the reader content with gzip encoding.
+func (gc GzipCompressor) Compress(w io.Writer, src io.Reader) (int64, error) {
+	zw := gzip.NewWriter(w)
+
+	size, err := io.Copy(zw, src)
+	_ = zw.Close()
+
+	return size, err
+}
+
+// Decompress the reader content with gzip encoding.
+func (gc GzipCompressor) Decompress(reader io.ReadCloser) (io.ReadCloser, error) {
+	compressionReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return readCloserWrapper{
+		CompressionReader: compressionReader,
+		OriginalReader:    reader,
+	}, nil
+}

--- a/utils/compression/zstd.go
+++ b/utils/compression/zstd.go
@@ -15,7 +15,7 @@ const (
 // ZstdCompressor implements the compression handler for zstandard encoding.
 type ZstdCompressor struct{}
 
-// Compress the reader content with gzip encoding.
+// Compress the reader content with zstd encoding.
 func (zc ZstdCompressor) Compress(w io.Writer, src io.Reader) (int64, error) {
 	zw, err := zstd.NewWriter(w)
 	if err != nil {
@@ -28,7 +28,7 @@ func (zc ZstdCompressor) Compress(w io.Writer, src io.Reader) (int64, error) {
 	return size, err
 }
 
-// Decompress the reader content with gzip encoding.
+// Decompress the reader content with zstd encoding.
 func (zc ZstdCompressor) Decompress(reader io.ReadCloser) (io.ReadCloser, error) {
 	compressionReader, err := zstd.NewReader(reader)
 	if err != nil {

--- a/utils/compression/zstd.go
+++ b/utils/compression/zstd.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	EncodingZstd = "zstd"
+	// EncodingZstd represents the Zstandard compression format.
+	EncodingZstd CompressionFormat = "zstd"
 )
 
 // ZstdCompressor implements the compression handler for zstandard encoding.

--- a/utils/compression/zstd.go
+++ b/utils/compression/zstd.go
@@ -1,0 +1,53 @@
+package compression
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+const (
+	EncodingZstd = "zstd"
+)
+
+// ZstdCompressor implements the compression handler for zstandard encoding.
+type ZstdCompressor struct{}
+
+// Compress the reader content with gzip encoding.
+func (zc ZstdCompressor) Compress(w io.Writer, src io.Reader) (int64, error) {
+	zw, err := zstd.NewWriter(w)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create the zstd writer: %w", err)
+	}
+
+	size, err := io.Copy(zw, src)
+	_ = zw.Close()
+
+	return size, err
+}
+
+// Decompress the reader content with gzip encoding.
+func (zc ZstdCompressor) Decompress(reader io.ReadCloser) (io.ReadCloser, error) {
+	compressionReader, err := zstd.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return readCloserWrapper{
+		CompressionReader: &zstdReader{
+			Decoder: compressionReader,
+		},
+		OriginalReader: reader,
+	}, nil
+}
+
+type zstdReader struct {
+	*zstd.Decoder
+}
+
+func (zd *zstdReader) Close() error {
+	zd.Decoder.Close()
+
+	return nil
+}


### PR DESCRIPTION
This pull request adds support for response compression in the connector's HTTP server, allowing clients to request compressed responses using standard encodings (gzip, deflate, zstd). The implementation introduces a new compression utility package, refactors the response writer to handle compression, and updates tests to verify compressed responses.
