### PR TITLE
ci: add explicit USER 65532

### DIFF
--- a/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl
@@ -13,5 +13,7 @@ FROM gcr.io/distroless/static-debian12:nonroot
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/ndc-cli /ndc-cli
 
+USER 65532
+
 # Run the web service on container startup.
 CMD ["/ndc-cli", "serve"]


### PR DESCRIPTION
This pull request introduces a small but important change to the Dockerfile template for new Hasura connector projects. The change ensures that the container runs as a non-root user for improved security.

* Security enhancement:
  * [`cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl`](diffhunk://#diff-085d4d72cbd7a64f8bc5b59d293b13af7202cb66ce16cde80be329d4cf8a19dcR16-R17): Added `USER 65532` to run the container as a non-root user.