### PR TITLE
misc: expose reusable logging functions

### DIFF
--- a/connector/server.go
+++ b/connector/server.go
@@ -127,7 +127,7 @@ func NewServer[Configuration any, State any](
 		return nil, err
 	}
 
-	ctx = context.WithValue(ctx, logContextKey, telemetry.Logger)
+	ctx = NewContextLogger(ctx, telemetry.Logger)
 
 	configuration, err := connector.ParseConfiguration(ctx, options.Configuration)
 	if err != nil {

--- a/connector/telemetry.go
+++ b/connector/telemetry.go
@@ -376,8 +376,8 @@ func setupOTelMetricsProvider(
 
 func newResource(serviceName, serviceVersion string) *resource.Resource {
 	hostname, _ := os.Hostname()
-
-	return resource.NewWithAttributes(semconv.SchemaURL,
+	attrs := append(
+		resource.Environment().Attributes(),
 		semconv.ServiceName(serviceName),
 		semconv.ServiceVersion(serviceVersion),
 		semconv.HostNameKey.String(hostname),
@@ -386,6 +386,8 @@ func newResource(serviceName, serviceVersion string) *resource.Resource {
 		semconv.ProcessPIDKey.Int64(int64(os.Getpid())),
 		attribute.String("ndc.spec.version", schema.NDCVersion),
 	)
+
+	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
 }
 
 func newPropagator() propagation.TextMapPropagator {


### PR DESCRIPTION
This pull request refactors how loggers are created, injected, and retrieved from context throughout the connector codebase. The changes centralize logger context handling, improve logger initialization, and enhance request ID generation for better traceability. Key updates include removing duplicated logger code, introducing helper functions for context and logger creation, and improving how request IDs are determined.

**Logger context management and initialization:**

* Introduced `NewContextLogger` and `NewJSONLogger` helper functions in `logger.go` to standardize logger creation and context injection, replacing custom logic and removing the old `initLogger` function. (`F055989eL15R15`, `F055989eL155R155`, `[[1]](diffhunk://#diff-e11f4a70ce3453d64ce4799174ff9740fde5fd7fa03b9ebee3116adf80819e70L71-R75)`, `[[2]](diffhunk://#diff-e11f4a70ce3453d64ce4799174ff9740fde5fd7fa03b9ebee3116adf80819e70L92-L112)`)
* Replaced all usages of the previous `logContextKey` and direct context manipulation with the new `loggerContextKey` and `NewContextLogger` for consistent logger propagation. (`F055989eL146R146`, `[connector/server.goL130-R130](diffhunk://#diff-83302262c5bae5edff30c79b5c66523a44fbf1435e957341aab5a68306140546L130-R130)`, `F823ecd0L232R232`)

**Request ID and tracing improvements:**

* Enhanced the `getRequestID` function to prefer the HTTP header, then use the trace ID from the OpenTelemetry span, and finally fall back to a generated UUID, improving request traceability. (`F823ecd0L321R321`, `F823ecd0L112R112`)

**Code cleanup and dependency management:**

* Removed unused imports (`os`, `strings`, and `context`) from files now using centralized logger helpers. (`[[1]](diffhunk://#diff-e11f4a70ce3453d64ce4799174ff9740fde5fd7fa03b9ebee3116adf80819e70L7-L8)`, `[[2]](diffhunk://#diff-7456e9f6044d6088e014ed4672d950d8d0d4bf054e8be927eb6ec76aef1c44feL5)`)
* Removed the obsolete `serverContextKey` and `logContextKey` definitions from `http.go`. (`F823ecd0L23R23`)

**Minor telemetry improvement:**

* Updated resource attribute gathering in telemetry setup to include environment attributes for more complete OpenTelemetry resource information. (`[[1]](diffhunk://#diff-5a289d8977f52b8f78b3c6e86385a4b6544a07440f869c477d5f49ddece84bdcL379-R380)`, `[[2]](diffhunk://#diff-5a289d8977f52b8f78b3c6e86385a4b6544a07440f869c477d5f49ddece84bdcR389-R390)`)