### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl
+++ b/cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # build context at repo root: docker build -f Dockerfile .
-FROM golang:1.26 AS builder
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.26-stable AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/example/reference/.hasura-connector/Dockerfile
+++ b/example/reference/.hasura-connector/Dockerfile
@@ -1,5 +1,5 @@
 # build context at repo root: docker build -f Dockerfile .
-FROM golang:1.22 AS builder
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.22-stable AS builder
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
## What

Re-homes the Go builder base images in this repo to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images`, using floating `-stable` aliases. These aliases auto-advance to the latest patched digest of the same version line, so patches are picked up without a version bump.

Per Hasura policy, every container deployed in Hasura infra must be pulled from the private Artifact Registry, not from upstream registries (Docker Hub, ghcr.io, gcr.io, quay.io, etc.). Upstream images are vendored there using a `preserve-source` path layout.

## Exact FROM swaps

- `example/reference/.hasura-connector/Dockerfile`
  - `FROM golang:1.22` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.22-stable`
- `cmd/hasura-ndc-go/command/internal/templates/new/.hasura-connector/Dockerfile.tmpl`
  - `FROM golang:1.26` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.26-stable`

The `AS builder` stage suffixes are preserved exactly. No other lines were changed; the `gcr.io/distroless/*` runtime stages are out of scope for this change and left untouched.

## Scope

Part of an org-wide Phase 1 migration: exact-match swaps only (same version line, no version bumps, no reformatting).
